### PR TITLE
fix: impl AsCelValue for FieldMask, Timestamp, Duration WKTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ name = "protovalidate-buffa"
 version = "0.2.0"
 dependencies = [
  "buffa",
+ "buffa-types",
  "cel",
  "chrono",
  "connectrpc",

--- a/crates/protovalidate-buffa/Cargo.toml
+++ b/crates/protovalidate-buffa/Cargo.toml
@@ -20,6 +20,7 @@ connect = ["dep:connectrpc"]
 
 [dependencies]
 buffa = "0.5"
+buffa-types = "0.5"
 protovalidate-buffa-macros = { path = "../protovalidate-buffa-macros", version = "0.2.0" }
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/crates/protovalidate-buffa/src/cel.rs
+++ b/crates/protovalidate-buffa/src/cel.rs
@@ -111,6 +111,49 @@ impl<T: AsCelValue + Default> ToCelValue for buffa::MessageField<T> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Well-Known Type `AsCelValue` impls.
+//
+// These let plugin-emitted code call
+// `::protovalidate_buffa::cel::AsCelValue::as_cel_value(inner)` for fields of
+// type `google.protobuf.FieldMask`, `google.protobuf.Timestamp`, and
+// `google.protobuf.Duration` — including the predefined-rule path, which binds
+// `this` to the field value via `AsCelValue`.
+//
+// `FieldMask` is exposed as a CEL map with one entry, `paths`, so expressions
+// like `this.paths.all(p, ...)` work. `Timestamp` and `Duration` are exposed
+// as native CEL `Timestamp` / `Duration` values, which carry their own
+// comparison and arithmetic operators in CEL.
+
+impl AsCelValue for buffa_types::google::protobuf::FieldMask {
+    fn as_cel_value(&self) -> Value {
+        let paths: Vec<Value> = self
+            .paths
+            .iter()
+            .map(|p| Value::String(Arc::new(p.clone())))
+            .collect();
+        let mut map: std::collections::HashMap<crate::cel_core::objects::Key, Value> =
+            std::collections::HashMap::with_capacity(1);
+        map.insert(
+            crate::cel_core::objects::Key::String(Arc::new("paths".to_string())),
+            Value::List(Arc::new(paths)),
+        );
+        Value::Map(map.into())
+    }
+}
+
+impl AsCelValue for buffa_types::google::protobuf::Timestamp {
+    fn as_cel_value(&self) -> Value {
+        Value::Timestamp(timestamp_from_secs_nanos(self.seconds, self.nanos))
+    }
+}
+
+impl AsCelValue for buffa_types::google::protobuf::Duration {
+    fn as_cel_value(&self) -> Value {
+        Value::Duration(duration_from_secs_nanos(self.seconds, self.nanos))
+    }
+}
+
 impl<E: buffa::Enumeration> ToCelValue for buffa::EnumValue<E> {
     fn to_cel_value(&self) -> Value {
         Value::Int(i64::from(self.to_i32()))

--- a/crates/protovalidate-buffa/tests/wkt_cel.rs
+++ b/crates/protovalidate-buffa/tests/wkt_cel.rs
@@ -1,0 +1,139 @@
+//! `AsCelValue` impls for `google.protobuf.FieldMask`, `Timestamp`, and
+//! `Duration`. Each test compiles and runs a real CEL expression against the
+//! WKT, exercising the same `CelConstraint::eval` path used by
+//! plugin-emitted field-level predefined rules.
+
+use buffa_types::google::protobuf::{Duration, FieldMask, Timestamp};
+use protovalidate_buffa::cel::CelConstraint;
+
+#[test]
+fn field_mask_paths_all_true() {
+    static RULE: CelConstraint = CelConstraint::new(
+        "test.field_mask.paths_all",
+        "every path must be 'display_name' or 'icon'",
+        "this.paths.all(p, p == 'display_name' || p == 'icon')",
+    );
+
+    let mask = FieldMask {
+        paths: vec!["display_name".to_string(), "icon".to_string()],
+        ..FieldMask::default()
+    };
+
+    RULE.eval(&mask).expect("rule should pass");
+}
+
+#[test]
+fn field_mask_paths_all_false() {
+    static RULE: CelConstraint = CelConstraint::new(
+        "test.field_mask.paths_all",
+        "path not allowed",
+        "this.paths.all(p, p == 'display_name')",
+    );
+
+    let mask = FieldMask {
+        paths: vec!["display_name".to_string(), "icon".to_string()],
+        ..FieldMask::default()
+    };
+
+    let err = RULE.eval(&mask).expect_err("rule should reject 'icon'");
+    assert_eq!(err.rule_id, "test.field_mask.paths_all");
+}
+
+#[test]
+fn field_mask_size_zero_empty() {
+    static RULE: CelConstraint = CelConstraint::new(
+        "test.field_mask.non_empty",
+        "field mask must not be empty",
+        "size(this.paths) > 0",
+    );
+
+    let empty = FieldMask::default();
+    RULE.eval(&empty).expect_err("empty mask should fail");
+
+    let nonempty = FieldMask {
+        paths: vec!["x".to_string()],
+        ..FieldMask::default()
+    };
+    RULE.eval(&nonempty).expect("non-empty mask should pass");
+}
+
+#[test]
+fn duration_compare_positive() {
+    static RULE: CelConstraint = CelConstraint::new(
+        "test.duration.positive",
+        "must be greater than zero",
+        "this > duration('0s')",
+    );
+
+    let positive = Duration {
+        seconds: 5,
+        nanos: 0,
+        ..Duration::default()
+    };
+    RULE.eval(&positive).expect("positive duration passes");
+
+    let zero = Duration::default();
+    RULE.eval(&zero).expect_err("zero duration fails");
+}
+
+#[test]
+fn duration_nanos_resolution() {
+    static RULE: CelConstraint = CelConstraint::new(
+        "test.duration.sub_second",
+        "must be at least 1ms",
+        "this >= duration('0.001s')",
+    );
+
+    let one_ms = Duration {
+        seconds: 0,
+        nanos: 1_000_000,
+        ..Duration::default()
+    };
+    RULE.eval(&one_ms).expect("1ms passes");
+
+    let half_ms = Duration {
+        seconds: 0,
+        nanos: 500_000,
+        ..Duration::default()
+    };
+    RULE.eval(&half_ms).expect_err("0.5ms fails");
+}
+
+#[test]
+fn timestamp_compare_before_max() {
+    static RULE: CelConstraint = CelConstraint::new(
+        "test.timestamp.before_max",
+        "must be before 9999-12-31",
+        "this < timestamp('9999-12-31T23:59:59Z')",
+    );
+
+    let ts = Timestamp {
+        seconds: 1_700_000_000,
+        nanos: 0,
+        ..Timestamp::default()
+    };
+    RULE.eval(&ts).expect("normal timestamp passes");
+}
+
+#[test]
+fn timestamp_in_past() {
+    static RULE: CelConstraint = CelConstraint::new(
+        "test.timestamp.in_past",
+        "must be in the past",
+        "this < now",
+    );
+
+    let past = Timestamp {
+        seconds: 1_000_000_000,
+        nanos: 0,
+        ..Timestamp::default()
+    };
+    RULE.eval(&past).expect("past timestamp passes");
+
+    let future = Timestamp {
+        seconds: 99_999_999_999,
+        nanos: 0,
+        ..Timestamp::default()
+    };
+    RULE.eval(&future).expect_err("future timestamp fails");
+}


### PR DESCRIPTION
## Summary

Field-level predefined CEL rules on `google.protobuf.FieldMask`, `Timestamp`, and `Duration` failed to compile because the codegen plugin emits `::protovalidate_buffa::cel::AsCelValue::as_cel_value(inner)` for the field value, but no `AsCelValue` impl existed for those WKT structs.

For example a downstream proto like

```proto
extend buf.validate.FieldMaskRules {
  repeated string mutable_paths = 80000001 [
    (buf.validate.predefined).cel = {
      id: "field_mask.mutable_paths"
      message: "update_mask paths must be one of the allowed values"
      expression: "this.paths.all(p, rule.exists(a, p == a || p.startsWith(a + '.')))"
    }
  ];
}

// ...

google.protobuf.FieldMask update_mask = 2 [
  (buf.validate.field).field_mask = {
    [pkg.mutable_paths]: ["display_name", "icon"]
  }
];
```

failed with `the trait bound FieldMask: AsCelValue is not satisfied`. Same shape for Timestamp- and Duration-typed fields.

## Fix

Three new `impl AsCelValue` blocks in `protovalidate-buffa/src/cel.rs`:

- `FieldMask` -> CEL `Map { paths: List<String> }`, so `this.paths.all(p, ...)`, `size(this.paths)`, etc. work.
- `Timestamp` -> native CEL `Timestamp` via the existing `timestamp_from_secs_nanos` helper, so `this < timestamp(...)`, `this < now`, `int(this)` work.
- `Duration` -> native CEL `Duration` via the existing `duration_from_secs_nanos` helper, so `this > duration('0s')` works.

Pulls `buffa-types = "0.5"` into the runtime crate to reference the WKT struct definitions. No changes to the codegen plugin or to public API beyond the new impls.

## Test plan

- [x] `cargo test -p protovalidate-buffa` — new `tests/wkt_cel.rs` exercises each impl through the real `CelConstraint::eval` path (`this.paths.all(...)`, `size(this.paths)`, `this > duration('0s')`, `this < timestamp('9999-12-31T23:59:59Z')`, `this < now`, sub-second nanos resolution).
- [x] `cargo test --workspace --all-targets` — no regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Downstream verification: bump consumer to released version, swap a message-level `update_mask` CEL for a field-level predefined rule on a `google.protobuf.FieldMask` field, confirm it compiles.