### PR TITLE
build!: update dependencies to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,10 +62,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "async-trait"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -108,8 +119,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "buffa"
-version = "0.5.2"
-source = "git+https://github.com/anthropics/buffa?rev=4c264ddd6fdd286f237dac0551fd420907b4864c#4c264ddd6fdd286f237dac0551fd420907b4864c"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941c714734a660caa93a210c531dec553cc0ef417890409914d24032c94ab840"
 dependencies = [
  "base64",
  "bytes",
@@ -122,8 +134,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-build"
-version = "0.5.2"
-source = "git+https://github.com/anthropics/buffa?rev=4c264ddd6fdd286f237dac0551fd420907b4864c#4c264ddd6fdd286f237dac0551fd420907b4864c"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96988700c7be5e4dd1dd22ee5daecd13090b24ec62003ee7fd4a9d7fef50a7c"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -132,8 +145,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-codegen"
-version = "0.5.2"
-source = "git+https://github.com/anthropics/buffa?rev=4c264ddd6fdd286f237dac0551fd420907b4864c#4c264ddd6fdd286f237dac0551fd420907b4864c"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693ea91be01336fb0084b2e7bb071be7393224c72f737c846471e4013e58c327"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -146,17 +160,20 @@ dependencies = [
 
 [[package]]
 name = "buffa-descriptor"
-version = "0.5.2"
-source = "git+https://github.com/anthropics/buffa?rev=4c264ddd6fdd286f237dac0551fd420907b4864c#4c264ddd6fdd286f237dac0551fd420907b4864c"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8df83adfcb525621f5a96c88e610f90aff1112ec57522d9b48a943df327394"
 dependencies = [
  "buffa",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -175,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -247,11 +264,12 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "connectrpc"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb80f9eb09b593a96880eb1c2588ac6319b129519de8c672f9b8b4ffdeaece"
+checksum = "3382e121377f6c160bbbe56f5809637ccbabff7edbf56bb8e96cc64e65998045"
 dependencies = [
  "async-compression",
+ "async-trait",
  "base64",
  "buffa",
  "bytes",
@@ -469,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -549,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -578,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -708,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -738,18 +756,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1036,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1288,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1301,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1311,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1321,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1334,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,3 @@ keywords = ["protobuf", "protovalidate", "buffa", "validation", "codegen"]
 all = { level = "deny", priority = -1 }
 pedantic = { level = "deny", priority = -1 }
 nursery = { level = "deny", priority = -1 }
-
-[patch.crates-io]
-buffa = { git = "https://github.com/anthropics/buffa", rev = "4c264ddd6fdd286f237dac0551fd420907b4864c" }
-buffa-codegen = { git = "https://github.com/anthropics/buffa", rev = "4c264ddd6fdd286f237dac0551fd420907b4864c" }
-buffa-build = { git = "https://github.com/anthropics/buffa", rev = "4c264ddd6fdd286f237dac0551fd420907b4864c" }
-buffa-descriptor = { git = "https://github.com/anthropics/buffa", rev = "4c264ddd6fdd286f237dac0551fd420907b4864c" }

--- a/crates/protoc-gen-protovalidate-buffa/Cargo.toml
+++ b/crates/protoc-gen-protovalidate-buffa/Cargo.toml
@@ -22,8 +22,8 @@ name = "protoc-gen-protovalidate-buffa"
 path = "src/main.rs"
 
 [dependencies]
-buffa = "0.5"
-buffa-codegen = "0.5"
+buffa = "0.6"
+buffa-codegen = "0.6"
 protovalidate-buffa-protos = { path = "../protovalidate-buffa-protos", version = "0.3.0" }
 proc-macro2 = "1"
 quote = "1"

--- a/crates/protovalidate-buffa-conformance/Cargo.toml
+++ b/crates/protovalidate-buffa-conformance/Cargo.toml
@@ -20,7 +20,7 @@ name = "protovalidate-buffa-conformance"
 path = "src/main.rs"
 
 [dependencies]
-buffa = "0.5"
+buffa = "0.6"
 protovalidate-buffa = { path = "../protovalidate-buffa", version = "0.3.0", default-features = false, features = ["tz"] }
 protovalidate-buffa-protos = { path = "../protovalidate-buffa-protos", version = "0.3.0" }
 anyhow = "1"
@@ -33,10 +33,10 @@ regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 [build-dependencies]
-buffa-build = "0.5"
+buffa-build = "0.6"
 protoc-gen-protovalidate-buffa = { path = "../protoc-gen-protovalidate-buffa", version = "0.3.0" }
-buffa = "0.5"
-buffa-codegen = "0.5"
+buffa = "0.6"
+buffa-codegen = "0.6"
 anyhow = "1"
 prettyplease = "0.2"
 syn = { version = "2", features = ["full"] }

--- a/crates/protovalidate-buffa-protos/Cargo.toml
+++ b/crates/protovalidate-buffa-protos/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-buffa = "0.5"
+buffa = "0.6"
 
 [build-dependencies]
-buffa-build = "0.5"
+buffa-build = "0.6"

--- a/crates/protovalidate-buffa/Cargo.toml
+++ b/crates/protovalidate-buffa/Cargo.toml
@@ -26,7 +26,7 @@ connect = ["dep:connectrpc"]
 tz = ["dep:chrono-tz"]
 
 [dependencies]
-buffa = "0.5"
+buffa = "0.6"
 protovalidate-buffa-macros = { path = "../protovalidate-buffa-macros", version = "0.3.0" }
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
@@ -35,6 +35,6 @@ uuid = "1"
 ulid = "1"
 ipnet = "2"
 fluent-uri = "0.4"
-connectrpc = { version = "0.4", optional = true }
+connectrpc = { version = "0.6", optional = true }
 percent-encoding = "2"
 http = "1"


### PR DESCRIPTION
## Summary
- update buffa, buffa-build, and buffa-codegen to 0.6
- update connectrpc to 0.6
- remove the old buffa git patch pin so published crates resolve directly
- refresh Cargo.lock with transitive dependency updates

## Impact
This is marked breaking because the public dependency floor for buffa and connectrpc moves to their latest major/minor lines.

## Validation
- cargo test --workspace
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings