### PR TITLE
fix: escape Rust keyword field/oneof names in generated accessors

### DIFF
--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
@@ -59,7 +59,7 @@ pub fn emit_message_level(
         if is_unsupported_wkt_field_for_cel(&f.field_type) {
             continue;
         }
-        let field_ident = format_ident!("{}", f.field_name);
+        let field_ident = crate::emit::field_ident(&f.field_name);
         let field_name = &f.field_name;
         let fnum = f.field_number;
         // For repeated scalars the CEL rule path uses the element type; for
@@ -134,7 +134,7 @@ pub fn emit_message_level(
             continue;
         }
         let default_family = predef_family_for(&f.field_type);
-        let field_ident = format_ident!("{}", f.field_name);
+        let field_ident = crate::emit::field_ident(&f.field_name);
         let field_name = &f.field_name;
         let fnum = f.field_number;
         for rule in &f.standard.predefined {

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
@@ -2655,7 +2655,7 @@ impl<'a> Compiler<'a> {
             .ok_or_else(|| {
                 FallbackReason::new(format!("opt_select: unknown field {field_name}"))
             })?;
-        let rust_ident = format_ident!("{}", entry.rust_ident);
+        let rust_ident = crate::emit::field_ident(&entry.rust_ident);
         let op_t = operand.tokens;
         // Map `Option<&Message>` through `.map(|m| m.<field>)`. The exact
         // shape depends on the field's CEL type and the binding semantics
@@ -3918,7 +3918,7 @@ fn select_message_field(
         .iter()
         .find(|e| e.proto_name == field)
         .ok_or_else(|| FallbackReason::new(format!("unknown field: {field}")))?;
-    let rust_ident = format_ident!("{}", entry.rust_ident);
+    let rust_ident = crate::emit::field_ident(&entry.rust_ident);
     let access = match &entry.kind {
         SchemaFieldKind::StringLike => match &entry.ty {
             CelType::Str { .. } => quote! { (#operand.#rust_ident.as_str()) },
@@ -4026,7 +4026,7 @@ fn has_message_field(
         .iter()
         .find(|e| e.proto_name == field)
         .ok_or_else(|| FallbackReason::new(format!("unknown field for has: {field}")))?;
-    let rust_ident = format_ident!("{}", entry.rust_ident);
+    let rust_ident = crate::emit::field_ident(&entry.rust_ident);
     let tokens = match &entry.kind {
         SchemaFieldKind::Scalar => match &entry.ty {
             CelType::Int => {

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
@@ -39,7 +39,7 @@ pub fn emit(
         return Ok(quote! {});
     }
 
-    let accessor = safe_ident(&field.field_name);
+    let accessor = crate::emit::field_ident(&field.field_name);
     let name_lit = &field.field_name;
     let mut blocks: Vec<TokenStream> = Vec::new();
 
@@ -4977,14 +4977,6 @@ pub(crate) const fn kind_to_field_type(k: &FieldKind) -> &'static str {
         FieldKind::Enum { .. } => "Enum",
         FieldKind::Message { .. } | FieldKind::Wrapper(_) => "Message",
         FieldKind::Repeated(_) | FieldKind::Map { .. } | FieldKind::Optional(_) => "Message",
-    }
-}
-
-fn safe_ident(name: &str) -> syn::Ident {
-    if syn::parse_str::<syn::Ident>(name).is_ok() {
-        format_ident!("{}", name)
-    } else {
-        syn::Ident::new_raw(name, proc_macro2::Span::call_site())
     }
 }
 

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
@@ -31,6 +31,18 @@ pub mod field;
 pub mod oneof;
 pub mod repeated;
 
+/// Build the Rust identifier that accesses a proto field (or oneof) on a
+/// buffa-generated struct.
+///
+/// Delegates to the same function buffa uses to name its struct fields
+/// (`buffa_codegen::idents::make_field_ident`), so accessors emitted here line
+/// up with the generated message types on keyword names (e.g. `type` →
+/// `r#type`, `self` → `self_`). Re-deriving idents with
+/// `format_ident!`/`Ident::new`/`parse_str` instead would panic or mismatch.
+pub(crate) fn field_ident(name: &str) -> proc_macro2::Ident {
+    buffa_codegen::idents::make_field_ident(name)
+}
+
 /// Render one output `.rs` file per source `.proto` file.
 ///
 /// Output path: `"example/v1/foo.proto"` → `"example.v1.foo.rs"`.
@@ -333,7 +345,7 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
             if implicit_ignore.contains(f.field_name.as_str())
                 && !matches!(f.ignore, crate::scan::Ignore::Always)
             {
-                let accessor = syn::Ident::new(&f.field_name, proc_macro2::Span::call_site());
+                let accessor = field_ident(&f.field_name);
                 let guard: Option<TokenStream> = match &f.field_type {
                     crate::scan::FieldKind::String | crate::scan::FieldKind::Bytes => {
                         Some(quote! { !self.#accessor.is_empty() })
@@ -479,15 +491,13 @@ fn emit_message_oneof(
     msg: &crate::scan::MessageValidators,
     spec: &crate::scan::MessageOneofSpec,
 ) -> TokenStream {
-    use proc_macro2::Span;
-
     use crate::scan::FieldKind;
     let checks: Vec<TokenStream> = spec
         .fields
         .iter()
         .filter_map(|name| {
             let fv = msg.field_rules.iter().find(|f| &f.field_name == name)?;
-            let ident = syn::Ident::new(&fv.field_name, Span::call_site());
+            let ident = field_ident(&fv.field_name);
             // "Set" semantics per protovalidate-go for message.oneof:
             // messages: present; repeated/map: non-empty; proto3 optional: is_some;
             // scalar: always counted as set (we can't distinguish default from unset).

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::parse_str;
 
 use crate::scan::{FieldKind, FieldValidator, OneofValidator};
 
@@ -16,8 +15,9 @@ use crate::scan::{FieldKind, FieldValidator, OneofValidator};
 ///
 /// # Errors
 ///
-/// Returns an error if the oneof name or a variant field name cannot be parsed
-/// as a valid Rust identifier (e.g. contains characters not allowed in identifiers).
+/// Returns an error if a variant's enum-rule type reference cannot be resolved
+/// to a local Rust path. (Field/oneof names are escaped via
+/// [`crate::emit::field_ident`], which is infallible.)
 pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
     let has_required = v.required;
     // If nothing to emit at all, skip.
@@ -27,11 +27,16 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
         return Ok(quote! {});
     }
 
-    let accessor = parse_str::<syn::Ident>(&v.name)?;
+    let accessor = crate::emit::field_ident(&v.name);
     let name_lit = &v.name;
 
     // The module name buffa generates for a message's oneof is the snake_case of
     // the parent message name, e.g. `CreateGradingRequest` → `create_grading_request`.
+    // These are constant across all variants, so derive them once and pass them
+    // down to the per-variant emitters.
+    let module_ident = crate::emit::field_ident(&to_snake_case(&v.parent_msg_name));
+    let oneof_enum_ident = crate::emit::field_ident(&to_pascal_case(&v.name));
+
     let none_arm = if has_required {
         quote! {
             None => {
@@ -66,14 +71,15 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
         .fields
         .iter()
         .filter(|f| has_field_rules(f))
-        .map(|f| emit_variant_arm(v, f))
+        .map(|f| emit_variant_arm(f, &module_ident, &oneof_enum_ident))
         .collect::<Result<Vec<_>>>()?
         .into_iter()
         .filter(|ts| !ts.is_empty())
         .collect();
 
     // Compute required_variant_blocks early so they survive all early-return paths.
-    let required_variant_blocks = emit_required_variant_blocks(v)?;
+    let required_variant_blocks =
+        emit_required_variant_blocks(v, &accessor, &module_ident, &oneof_enum_ident);
 
     // If no variant has rules, we only need the None check (already handled above).
     if some_arms.is_empty() && !has_required && !has_required_variants {
@@ -133,9 +139,13 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
     })
 }
 
-fn emit_required_variant_blocks(v: &OneofValidator) -> Result<Vec<TokenStream>> {
+fn emit_required_variant_blocks(
+    v: &OneofValidator,
+    accessor: &syn::Ident,
+    module_ident: &syn::Ident,
+    oneof_enum_ident: &syn::Ident,
+) -> Vec<TokenStream> {
     let mut out: Vec<TokenStream> = Vec::new();
-    let accessor = parse_str::<syn::Ident>(&v.name)?;
     for f in &v.fields {
         if !f.required {
             continue;
@@ -143,12 +153,8 @@ fn emit_required_variant_blocks(v: &OneofValidator) -> Result<Vec<TokenStream>> 
         if matches!(f.ignore, crate::scan::Ignore::Always) {
             continue;
         }
-        let module_name_str = to_snake_case(&v.parent_msg_name);
-        let module_ident: syn::Ident = parse_str(&module_name_str)?;
-        let oneof_enum_str = to_pascal_case(&v.name);
-        let oneof_enum_ident: syn::Ident = parse_str(&oneof_enum_str)?;
         let variant_name_str = to_pascal_case(&f.field_name);
-        let variant_ident: syn::Ident = parse_str(&variant_name_str)?;
+        let variant_ident = crate::emit::field_ident(&variant_name_str);
         let name_lit = &f.field_name;
         let fnum = f.field_number;
         let field_ty = match f.field_type {
@@ -205,7 +211,7 @@ fn emit_required_variant_blocks(v: &OneofValidator) -> Result<Vec<TokenStream>> 
             }
         });
     }
-    Ok(out)
+    out
 }
 
 /// Returns true if a field has any rules that produce emitted checks.
@@ -231,18 +237,18 @@ fn has_field_rules(f: &FieldValidator) -> bool {
 }
 
 /// Emit a `Some(Variant(v)) => { ... }` match arm for a single oneof field.
-fn emit_variant_arm(v: &OneofValidator, f: &FieldValidator) -> Result<TokenStream> {
+fn emit_variant_arm(
+    f: &FieldValidator,
+    module_ident: &syn::Ident,
+    oneof_enum_ident: &syn::Ident,
+) -> Result<TokenStream> {
     if matches!(f.ignore, crate::scan::Ignore::Always) {
         return Ok(quote! {});
     }
-    let module_name_str = to_snake_case(&v.parent_msg_name);
-    let module_ident = parse_str::<syn::Ident>(&module_name_str)?;
-    let oneof_enum_str = to_pascal_case(&v.name);
-    let oneof_enum_ident = parse_str::<syn::Ident>(&oneof_enum_str)?;
 
     // Buffa's variant name: PascalCase of the field name.
     let variant_name_str = to_pascal_case(&f.field_name);
-    let variant_ident = parse_str::<syn::Ident>(&variant_name_str)?;
+    let variant_ident = crate::emit::field_ident(&variant_name_str);
 
     let name_lit = &f.field_name;
     let val_ident = format_ident!("v");

--- a/crates/protoc-gen-protovalidate-buffa/tests/keyword_idents.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/keyword_idents.rs
@@ -1,0 +1,114 @@
+//! Regression tests for fields / oneofs whose proto name is a Rust keyword.
+//!
+//! buffa names the generated struct field for a proto field `type` as the raw
+//! identifier `r#type` (and `self`/`super`/`Self`/`crate`, which cannot be raw
+//! identifiers, as `self_`/`super_`/`Self_`/`crate_`). The validator codegen
+//! must emit accessors that match, otherwise `prettyplease`/`syn` cannot parse
+//! the output and `proc_macro2::Ident::new` panics at generation time.
+//!
+//! See `buffa_codegen::idents::make_field_ident` for the source-of-truth
+//! escaping these tests pin down.
+
+use protoc_gen_protovalidate_buffa::emit::render;
+use protoc_gen_protovalidate_buffa::scan::{
+    CelRule, FieldKind, FieldValidator, Ignore, MessageValidators, OneofValidator, StandardRules,
+};
+
+/// Concatenate every emitted file's body so a test can assert on the generated
+/// source regardless of which per-package / per-source file an accessor landed
+/// in.
+fn render_to_source(msg: MessageValidators) -> String {
+    let files = render(&[msg]).expect("render must not fail for keyword-named fields");
+    files
+        .into_iter()
+        .filter_map(|f| f.content)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn field(name: &str, field_type: FieldKind) -> FieldValidator {
+    FieldValidator {
+        field_number: 1,
+        field_name: name.to_string(),
+        field_type,
+        required: false,
+        ignore: Ignore::Unspecified,
+        standard: StandardRules::default(),
+        cel: Vec::new(),
+        oneof_index: None,
+        oneof_name: None,
+        is_legacy_required: false,
+        is_group: false,
+    }
+}
+
+fn message(field_rules: Vec<FieldValidator>) -> MessageValidators {
+    MessageValidators {
+        proto_name: "kw.v1.M".to_string(),
+        package: "kw.v1".to_string(),
+        source_file: "kw.proto".to_string(),
+        message_cel: Vec::new(),
+        message_oneofs: Vec::new(),
+        field_rules,
+        oneof_rules: Vec::new(),
+        compile_error: None,
+    }
+}
+
+/// A plain (raw-able) keyword field name must become `self.r#type`.
+#[test]
+fn required_field_named_type_uses_raw_ident() {
+    let mut f = field("type", FieldKind::String);
+    f.required = true;
+    let src = render_to_source(message(vec![f]));
+    assert!(
+        src.contains("self.r#type"),
+        "expected `self.r#type` accessor, generated source was:\n{src}"
+    );
+}
+
+/// `self` cannot be a raw identifier, so buffa suffixes it: the accessor must
+/// be `self.self_`. Today this panics in `Ident::new_raw`.
+#[test]
+fn required_field_named_self_uses_suffixed_ident() {
+    let mut f = field("self", FieldKind::String);
+    f.required = true;
+    let src = render_to_source(message(vec![f]));
+    assert!(
+        src.contains("self.self_"),
+        "expected `self.self_` accessor, generated source was:\n{src}"
+    );
+}
+
+/// A field-level CEL rule on a keyword-named field. Today the field accessor is
+/// built with `format_ident!("{}", "type")`, which panics.
+#[test]
+fn field_cel_on_keyword_named_field_does_not_panic() {
+    let mut f = field("type", FieldKind::String);
+    f.cel = vec![CelRule {
+        id: "type_rule".to_string(),
+        message: "must be non-empty".to_string(),
+        expression: "this != ''".to_string(),
+        is_cel_expression: false,
+    }];
+    // Must not panic during render.
+    let _ = render_to_source(message(vec![f]));
+}
+
+/// A required oneof whose proto name is a keyword. Today the accessor is built
+/// with `parse_str::<syn::Ident>("type")`, which returns `Err` and fails codegen.
+#[test]
+fn required_oneof_named_type_uses_raw_ident() {
+    let mut msg = message(Vec::new());
+    msg.oneof_rules = vec![OneofValidator {
+        name: "type".to_string(),
+        required: true,
+        parent_msg_name: "M".to_string(),
+        fields: Vec::new(),
+    }];
+    let src = render_to_source(msg);
+    assert!(
+        src.contains("self.r#type"),
+        "expected `self.r#type` oneof accessor, generated source was:\n{src}"
+    );
+}


### PR DESCRIPTION
The plugin built field accessors (`self.<field>`) straight from raw proto names, so any field or oneof named with a Rust keyword broke codegen: `format_ident!` emitted invalid `self.type`, `parse_str::<Ident>` returned `Err`, and `Ident::new`/`new_raw` panicked on non-raw-able keywords like `self`. buffa names the underlying struct fields via `make_field_ident` (`type` -> `r#type`, `self` -> `self_`), so the accessors never lined up.

Route every proto-name -> ident site through a shared `field_ident` helper that delegates to `buffa_codegen::idents::make_field_ident`, guaranteeing the emitted accessors match buffa's generated structs by construction. Covers the field-CEL, predefined-rule, CEL field-select, oneof, and message-`oneof` paths, and replaces the incomplete local `safe_ident` (which panicked on `self`/`super`/`Self`/`crate`).

Add tests/keyword_idents.rs exercising the real emit::render pipeline for keyword-named fields and oneofs.