### PR TITLE
fix!: consolidate keyword, connectrpc, and buffa fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,18 +42,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "async-compression"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
-dependencies = [
- "compression-codecs",
- "compression-core",
- "pin-project-lite",
- "tokio",
-]
 
 [[package]]
 name = "async-trait"
@@ -197,8 +179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -244,36 +224,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "compression-codecs"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
-dependencies = [
- "compression-core",
- "flate2",
- "memchr",
- "zstd",
- "zstd-safe",
-]
-
-[[package]]
-name = "compression-core"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
-
-[[package]]
 name = "connectrpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3382e121377f6c160bbbe56f5809637ccbabff7edbf56bb8e96cc64e65998045"
 dependencies = [
- "async-compression",
  "async-trait",
  "base64",
  "buffa",
  "bytes",
- "flate2",
  "futures",
  "http",
  "http-body",
@@ -288,7 +247,6 @@ dependencies = [
  "tower",
  "tracing",
  "wasm-bindgen-futures",
- "zstd",
 ]
 
 [[package]]
@@ -296,15 +254,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "equivalent"
@@ -333,17 +282,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
- "zlib-rs",
-]
 
 [[package]]
 name = "fluent-uri"
@@ -585,16 +523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,16 +584,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "murmur3"
@@ -779,12 +697,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -1070,12 +982,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -1586,41 +1492,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,25 +100,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
-name = "buffa"
-version = "0.6.0"
+name = "borsh"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941c714734a660caa93a210c531dec553cc0ef417890409914d24032c94ab840"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "buffa"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec95898e2ef31d6266042f21c398fa5ff8334d14d6b2ac5fb38b55448d94f595"
 dependencies = [
  "base64",
  "bytes",
+ "compact_str",
+ "ecow",
  "hashbrown 0.15.5",
  "once_cell",
  "serde",
  "serde_json",
+ "smol_str",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "buffa-build"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96988700c7be5e4dd1dd22ee5daecd13090b24ec62003ee7fd4a9d7fef50a7c"
+checksum = "c26e1e2ec3ddd680a25e60687e0dca72fc2326f01d2ff26acbd8c266a3664693"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -127,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-codegen"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693ea91be01336fb0084b2e7bb071be7393224c72f737c846471e4013e58c327"
+checksum = "855364959e603cad456c1656bcf57f431ae6e5b4d4e4f166f7d594df882b6218"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -142,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-descriptor"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8df83adfcb525621f5a96c88e610f90aff1112ec57522d9b48a943df327394"
+checksum = "f74c0bf128c53f22b0fc3c1e8e66969cd21375879061293fd4e5298e839099a9"
 dependencies = [
  "buffa",
  "serde",
@@ -170,6 +183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -203,6 +225,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,10 +252,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "connectrpc"
-version = "0.6.0"
+name = "compact_str"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3382e121377f6c160bbbe56f5809637ccbabff7edbf56bb8e96cc64e65998045"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "connectrpc"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003fac88ace432fd8e6adbe13da8b20e90613b89e70c72186c505ad1bea307b2"
 dependencies = [
  "async-trait",
  "base64",
@@ -254,6 +297,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -923,6 +975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1058,22 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/crates/protoc-gen-protovalidate-buffa/Cargo.toml
+++ b/crates/protoc-gen-protovalidate-buffa/Cargo.toml
@@ -22,8 +22,8 @@ name = "protoc-gen-protovalidate-buffa"
 path = "src/main.rs"
 
 [dependencies]
-buffa = "0.6"
-buffa-codegen = "0.6"
+buffa = "0.7"
+buffa-codegen = "0.7"
 protovalidate-buffa-protos = { path = "../protovalidate-buffa-protos", version = "0.4.0" }
 proc-macro2 = "1"
 quote = "1"

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
@@ -59,7 +59,7 @@ pub fn emit_message_level(
         if is_unsupported_wkt_field_for_cel(&f.field_type) {
             continue;
         }
-        let field_ident = format_ident!("{}", f.field_name);
+        let field_ident = crate::emit::field_ident(&f.field_name);
         let field_name = &f.field_name;
         let fnum = f.field_number;
         // For repeated scalars the CEL rule path uses the element type; for
@@ -134,7 +134,7 @@ pub fn emit_message_level(
             continue;
         }
         let default_family = predef_family_for(&f.field_type);
-        let field_ident = format_ident!("{}", f.field_name);
+        let field_ident = crate::emit::field_ident(&f.field_name);
         let field_name = &f.field_name;
         let fnum = f.field_number;
         for rule in &f.standard.predefined {

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
@@ -2655,7 +2655,7 @@ impl<'a> Compiler<'a> {
             .ok_or_else(|| {
                 FallbackReason::new(format!("opt_select: unknown field {field_name}"))
             })?;
-        let rust_ident = format_ident!("{}", entry.rust_ident);
+        let rust_ident = crate::emit::field_ident(&entry.rust_ident);
         let op_t = operand.tokens;
         // Map `Option<&Message>` through `.map(|m| m.<field>)`. The exact
         // shape depends on the field's CEL type and the binding semantics
@@ -3918,7 +3918,7 @@ fn select_message_field(
         .iter()
         .find(|e| e.proto_name == field)
         .ok_or_else(|| FallbackReason::new(format!("unknown field: {field}")))?;
-    let rust_ident = format_ident!("{}", entry.rust_ident);
+    let rust_ident = crate::emit::field_ident(&entry.rust_ident);
     let access = match &entry.kind {
         SchemaFieldKind::StringLike => match &entry.ty {
             CelType::Str { .. } => quote! { (#operand.#rust_ident.as_str()) },
@@ -4026,7 +4026,7 @@ fn has_message_field(
         .iter()
         .find(|e| e.proto_name == field)
         .ok_or_else(|| FallbackReason::new(format!("unknown field for has: {field}")))?;
-    let rust_ident = format_ident!("{}", entry.rust_ident);
+    let rust_ident = crate::emit::field_ident(&entry.rust_ident);
     let tokens = match &entry.kind {
         SchemaFieldKind::Scalar => match &entry.ty {
             CelType::Int => {

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
@@ -39,7 +39,7 @@ pub fn emit(
         return Ok(quote! {});
     }
 
-    let accessor = safe_ident(&field.field_name);
+    let accessor = crate::emit::field_ident(&field.field_name);
     let name_lit = &field.field_name;
     let mut blocks: Vec<TokenStream> = Vec::new();
 
@@ -4977,14 +4977,6 @@ pub(crate) const fn kind_to_field_type(k: &FieldKind) -> &'static str {
         FieldKind::Enum { .. } => "Enum",
         FieldKind::Message { .. } | FieldKind::Wrapper(_) => "Message",
         FieldKind::Repeated(_) | FieldKind::Map { .. } | FieldKind::Optional(_) => "Message",
-    }
-}
-
-fn safe_ident(name: &str) -> syn::Ident {
-    if syn::parse_str::<syn::Ident>(name).is_ok() {
-        format_ident!("{}", name)
-    } else {
-        syn::Ident::new_raw(name, proc_macro2::Span::call_site())
     }
 }
 

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
@@ -31,6 +31,18 @@ pub mod field;
 pub mod oneof;
 pub mod repeated;
 
+/// Build the Rust identifier that accesses a proto field (or oneof) on a
+/// buffa-generated struct.
+///
+/// Delegates to the same function buffa uses to name its struct fields
+/// (`buffa_codegen::idents::make_field_ident`), so accessors emitted here line
+/// up with the generated message types on keyword names (e.g. `type` →
+/// `r#type`, `self` → `self_`). Re-deriving idents with
+/// `format_ident!`/`Ident::new`/`parse_str` instead would panic or mismatch.
+pub(crate) fn field_ident(name: &str) -> proc_macro2::Ident {
+    buffa_codegen::idents::make_field_ident(name)
+}
+
 /// Render one output `.rs` file per source `.proto` file.
 ///
 /// Output path: `"example/v1/foo.proto"` → `"example.v1.foo.rs"`.
@@ -333,7 +345,7 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
             if implicit_ignore.contains(f.field_name.as_str())
                 && !matches!(f.ignore, crate::scan::Ignore::Always)
             {
-                let accessor = syn::Ident::new(&f.field_name, proc_macro2::Span::call_site());
+                let accessor = field_ident(&f.field_name);
                 let guard: Option<TokenStream> = match &f.field_type {
                     crate::scan::FieldKind::String | crate::scan::FieldKind::Bytes => {
                         Some(quote! { !self.#accessor.is_empty() })
@@ -479,15 +491,13 @@ fn emit_message_oneof(
     msg: &crate::scan::MessageValidators,
     spec: &crate::scan::MessageOneofSpec,
 ) -> TokenStream {
-    use proc_macro2::Span;
-
     use crate::scan::FieldKind;
     let checks: Vec<TokenStream> = spec
         .fields
         .iter()
         .filter_map(|name| {
             let fv = msg.field_rules.iter().find(|f| &f.field_name == name)?;
-            let ident = syn::Ident::new(&fv.field_name, Span::call_site());
+            let ident = field_ident(&fv.field_name);
             // "Set" semantics per protovalidate-go for message.oneof:
             // messages: present; repeated/map: non-empty; proto3 optional: is_some;
             // scalar: always counted as set (we can't distinguish default from unset).

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::parse_str;
 
 use crate::scan::{FieldKind, FieldValidator, OneofValidator};
 
@@ -16,8 +15,9 @@ use crate::scan::{FieldKind, FieldValidator, OneofValidator};
 ///
 /// # Errors
 ///
-/// Returns an error if the oneof name or a variant field name cannot be parsed
-/// as a valid Rust identifier (e.g. contains characters not allowed in identifiers).
+/// Returns an error if a variant's enum-rule type reference cannot be resolved
+/// to a local Rust path. (Field/oneof names are escaped via
+/// [`crate::emit::field_ident`], which is infallible.)
 pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
     let has_required = v.required;
     // If nothing to emit at all, skip.
@@ -27,11 +27,16 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
         return Ok(quote! {});
     }
 
-    let accessor = parse_str::<syn::Ident>(&v.name)?;
+    let accessor = crate::emit::field_ident(&v.name);
     let name_lit = &v.name;
 
     // The module name buffa generates for a message's oneof is the snake_case of
     // the parent message name, e.g. `CreateGradingRequest` → `create_grading_request`.
+    // These are constant across all variants, so derive them once and pass them
+    // down to the per-variant emitters.
+    let module_ident = crate::emit::field_ident(&to_snake_case(&v.parent_msg_name));
+    let oneof_enum_ident = crate::emit::field_ident(&to_pascal_case(&v.name));
+
     let none_arm = if has_required {
         quote! {
             None => {
@@ -66,14 +71,15 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
         .fields
         .iter()
         .filter(|f| has_field_rules(f))
-        .map(|f| emit_variant_arm(v, f))
+        .map(|f| emit_variant_arm(f, &module_ident, &oneof_enum_ident))
         .collect::<Result<Vec<_>>>()?
         .into_iter()
         .filter(|ts| !ts.is_empty())
         .collect();
 
     // Compute required_variant_blocks early so they survive all early-return paths.
-    let required_variant_blocks = emit_required_variant_blocks(v)?;
+    let required_variant_blocks =
+        emit_required_variant_blocks(v, &accessor, &module_ident, &oneof_enum_ident);
 
     // If no variant has rules, we only need the None check (already handled above).
     if some_arms.is_empty() && !has_required && !has_required_variants {
@@ -133,9 +139,13 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
     })
 }
 
-fn emit_required_variant_blocks(v: &OneofValidator) -> Result<Vec<TokenStream>> {
+fn emit_required_variant_blocks(
+    v: &OneofValidator,
+    accessor: &syn::Ident,
+    module_ident: &syn::Ident,
+    oneof_enum_ident: &syn::Ident,
+) -> Vec<TokenStream> {
     let mut out: Vec<TokenStream> = Vec::new();
-    let accessor = parse_str::<syn::Ident>(&v.name)?;
     for f in &v.fields {
         if !f.required {
             continue;
@@ -143,12 +153,8 @@ fn emit_required_variant_blocks(v: &OneofValidator) -> Result<Vec<TokenStream>> 
         if matches!(f.ignore, crate::scan::Ignore::Always) {
             continue;
         }
-        let module_name_str = to_snake_case(&v.parent_msg_name);
-        let module_ident: syn::Ident = parse_str(&module_name_str)?;
-        let oneof_enum_str = to_pascal_case(&v.name);
-        let oneof_enum_ident: syn::Ident = parse_str(&oneof_enum_str)?;
         let variant_name_str = to_pascal_case(&f.field_name);
-        let variant_ident: syn::Ident = parse_str(&variant_name_str)?;
+        let variant_ident = crate::emit::field_ident(&variant_name_str);
         let name_lit = &f.field_name;
         let fnum = f.field_number;
         let field_ty = match f.field_type {
@@ -205,7 +211,7 @@ fn emit_required_variant_blocks(v: &OneofValidator) -> Result<Vec<TokenStream>> 
             }
         });
     }
-    Ok(out)
+    out
 }
 
 /// Returns true if a field has any rules that produce emitted checks.
@@ -231,18 +237,18 @@ fn has_field_rules(f: &FieldValidator) -> bool {
 }
 
 /// Emit a `Some(Variant(v)) => { ... }` match arm for a single oneof field.
-fn emit_variant_arm(v: &OneofValidator, f: &FieldValidator) -> Result<TokenStream> {
+fn emit_variant_arm(
+    f: &FieldValidator,
+    module_ident: &syn::Ident,
+    oneof_enum_ident: &syn::Ident,
+) -> Result<TokenStream> {
     if matches!(f.ignore, crate::scan::Ignore::Always) {
         return Ok(quote! {});
     }
-    let module_name_str = to_snake_case(&v.parent_msg_name);
-    let module_ident = parse_str::<syn::Ident>(&module_name_str)?;
-    let oneof_enum_str = to_pascal_case(&v.name);
-    let oneof_enum_ident = parse_str::<syn::Ident>(&oneof_enum_str)?;
 
     // Buffa's variant name: PascalCase of the field name.
     let variant_name_str = to_pascal_case(&f.field_name);
-    let variant_ident = parse_str::<syn::Ident>(&variant_name_str)?;
+    let variant_ident = crate::emit::field_ident(&variant_name_str);
 
     let name_lit = &f.field_name;
     let val_ident = format_ident!("v");

--- a/crates/protoc-gen-protovalidate-buffa/tests/keyword_idents.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/keyword_idents.rs
@@ -1,0 +1,114 @@
+//! Regression tests for fields / oneofs whose proto name is a Rust keyword.
+//!
+//! buffa names the generated struct field for a proto field `type` as the raw
+//! identifier `r#type` (and `self`/`super`/`Self`/`crate`, which cannot be raw
+//! identifiers, as `self_`/`super_`/`Self_`/`crate_`). The validator codegen
+//! must emit accessors that match, otherwise `prettyplease`/`syn` cannot parse
+//! the output and `proc_macro2::Ident::new` panics at generation time.
+//!
+//! See `buffa_codegen::idents::make_field_ident` for the source-of-truth
+//! escaping these tests pin down.
+
+use protoc_gen_protovalidate_buffa::emit::render;
+use protoc_gen_protovalidate_buffa::scan::{
+    CelRule, FieldKind, FieldValidator, Ignore, MessageValidators, OneofValidator, StandardRules,
+};
+
+/// Concatenate every emitted file's body so a test can assert on the generated
+/// source regardless of which per-package / per-source file an accessor landed
+/// in.
+fn render_to_source(msg: MessageValidators) -> String {
+    let files = render(&[msg]).expect("render must not fail for keyword-named fields");
+    files
+        .into_iter()
+        .filter_map(|f| f.content)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn field(name: &str, field_type: FieldKind) -> FieldValidator {
+    FieldValidator {
+        field_number: 1,
+        field_name: name.to_string(),
+        field_type,
+        required: false,
+        ignore: Ignore::Unspecified,
+        standard: StandardRules::default(),
+        cel: Vec::new(),
+        oneof_index: None,
+        oneof_name: None,
+        is_legacy_required: false,
+        is_group: false,
+    }
+}
+
+fn message(field_rules: Vec<FieldValidator>) -> MessageValidators {
+    MessageValidators {
+        proto_name: "kw.v1.M".to_string(),
+        package: "kw.v1".to_string(),
+        source_file: "kw.proto".to_string(),
+        message_cel: Vec::new(),
+        message_oneofs: Vec::new(),
+        field_rules,
+        oneof_rules: Vec::new(),
+        compile_error: None,
+    }
+}
+
+/// A plain (raw-able) keyword field name must become `self.r#type`.
+#[test]
+fn required_field_named_type_uses_raw_ident() {
+    let mut f = field("type", FieldKind::String);
+    f.required = true;
+    let src = render_to_source(message(vec![f]));
+    assert!(
+        src.contains("self.r#type"),
+        "expected `self.r#type` accessor, generated source was:\n{src}"
+    );
+}
+
+/// `self` cannot be a raw identifier, so buffa suffixes it: the accessor must
+/// be `self.self_`. Today this panics in `Ident::new_raw`.
+#[test]
+fn required_field_named_self_uses_suffixed_ident() {
+    let mut f = field("self", FieldKind::String);
+    f.required = true;
+    let src = render_to_source(message(vec![f]));
+    assert!(
+        src.contains("self.self_"),
+        "expected `self.self_` accessor, generated source was:\n{src}"
+    );
+}
+
+/// A field-level CEL rule on a keyword-named field. Today the field accessor is
+/// built with `format_ident!("{}", "type")`, which panics.
+#[test]
+fn field_cel_on_keyword_named_field_does_not_panic() {
+    let mut f = field("type", FieldKind::String);
+    f.cel = vec![CelRule {
+        id: "type_rule".to_string(),
+        message: "must be non-empty".to_string(),
+        expression: "this != ''".to_string(),
+        is_cel_expression: false,
+    }];
+    // Must not panic during render.
+    let _ = render_to_source(message(vec![f]));
+}
+
+/// A required oneof whose proto name is a keyword. Today the accessor is built
+/// with `parse_str::<syn::Ident>("type")`, which returns `Err` and fails codegen.
+#[test]
+fn required_oneof_named_type_uses_raw_ident() {
+    let mut msg = message(Vec::new());
+    msg.oneof_rules = vec![OneofValidator {
+        name: "type".to_string(),
+        required: true,
+        parent_msg_name: "M".to_string(),
+        fields: Vec::new(),
+    }];
+    let src = render_to_source(msg);
+    assert!(
+        src.contains("self.r#type"),
+        "expected `self.r#type` oneof accessor, generated source was:\n{src}"
+    );
+}

--- a/crates/protovalidate-buffa-conformance/Cargo.toml
+++ b/crates/protovalidate-buffa-conformance/Cargo.toml
@@ -20,7 +20,7 @@ name = "protovalidate-buffa-conformance"
 path = "src/main.rs"
 
 [dependencies]
-buffa = "0.6"
+buffa = "0.7"
 protovalidate-buffa = { path = "../protovalidate-buffa", version = "0.4.0", default-features = false, features = ["tz"] }
 protovalidate-buffa-protos = { path = "../protovalidate-buffa-protos", version = "0.4.0" }
 anyhow = "1"
@@ -33,10 +33,10 @@ regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 [build-dependencies]
-buffa-build = "0.6"
+buffa-build = "0.7"
 protoc-gen-protovalidate-buffa = { path = "../protoc-gen-protovalidate-buffa", version = "0.4.0" }
-buffa = "0.6"
-buffa-codegen = "0.6"
+buffa = "0.7"
+buffa-codegen = "0.7"
 anyhow = "1"
 prettyplease = "0.2"
 syn = { version = "2", features = ["full"] }

--- a/crates/protovalidate-buffa-protos/Cargo.toml
+++ b/crates/protovalidate-buffa-protos/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-buffa = "0.6"
+buffa = "0.7"
 
 [build-dependencies]
-buffa-build = "0.6"
+buffa-build = "0.7"

--- a/crates/protovalidate-buffa/Cargo.toml
+++ b/crates/protovalidate-buffa/Cargo.toml
@@ -35,6 +35,6 @@ uuid = "1"
 ulid = "1"
 ipnet = "2"
 fluent-uri = "0.4"
-connectrpc = { version = "0.6", optional = true }
+connectrpc = { version = "0.6", default-features = false, optional = true }
 percent-encoding = "2"
 http = "1"

--- a/crates/protovalidate-buffa/Cargo.toml
+++ b/crates/protovalidate-buffa/Cargo.toml
@@ -26,7 +26,7 @@ connect = ["dep:connectrpc"]
 tz = ["dep:chrono-tz"]
 
 [dependencies]
-buffa = "0.6"
+buffa = "0.7"
 protovalidate-buffa-macros = { path = "../protovalidate-buffa-macros", version = "0.3.0" }
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
@@ -35,6 +35,6 @@ uuid = "1"
 ulid = "1"
 ipnet = "2"
 fluent-uri = "0.4"
-connectrpc = { version = "0.6", default-features = false, optional = true }
+connectrpc = { version = "0.7", default-features = false, optional = true }
 percent-encoding = "2"
 http = "1"


### PR DESCRIPTION
## Summary

- escape Rust keyword field and oneof accessors through buffa's field ident helper
- disable connectrpc default features for the optional connect integration
- bump buffa, buffa-build, buffa-codegen, and connectrpc to the 0.7 line

Supersedes #14, #15, and #16.

## Verification

- cargo fmt --all --check
- cargo test -p protovalidate-buffa --all-features
- cargo tree -p protovalidate-buffa --features connect | rg 'connectrpc|async-compression|flate2|zstd'

Full workspace tests still require protoc on PATH for protovalidate-buffa-protos build scripts.