### PR TITLE
fix: validate Connect ServiceRequest handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Compared to reflection-based implementations, the codegen approach has two chara
 | Crate | Purpose |
 |-------|---------|
 | [`protovalidate-buffa`](crates/protovalidate-buffa/) | Runtime library: `Validate` trait, structured `ValidationError` (with typed `compile_error` / `runtime_error` slots), `Violation` / `FieldPath`, rule helpers, `CelScalar` widening trait + Duration/Timestamp helpers, Connect error adapter. CEL rules are transpiled to native Rust at codegen time, so the runtime carries no interpreter. |
-| [`protovalidate-buffa-macros`](crates/protovalidate-buffa-macros/) | `#[connect_impl]` attribute macro — inserts `req.validate()?` at the top of every handler in a service `impl` block. Re-exported from the runtime crate. |
+| [`protovalidate-buffa-macros`](crates/protovalidate-buffa-macros/) | `#[connect_impl]` attribute macro — inserts request validation at the top of every handler in a service `impl` block. Re-exported from the runtime crate. |
 | [`protoc-gen-protovalidate-buffa`](crates/protoc-gen-protovalidate-buffa/) | Codegen plugin. Reads `(buf.validate.*)` extensions off descriptors via buffa's `ExtensionSet`, emits `impl Validate for Foo` blocks. Wire into `buf.gen.yaml`. |
 | [`protovalidate-buffa-protos`](crates/protovalidate-buffa-protos/) | Compiled Rust for `buf/validate/validate.proto` (vendored under `proto/`). Consumed by the codegen plugin. |
 
@@ -83,9 +83,9 @@ impl UserService for UserServiceImpl {
     async fn create_user(
         &self,
         ctx: Context,
-        request: OwnedView<pb::CreateUserRequestView<'static>>,
+        request: connectrpc::ServiceRequest<'_, pb::CreateUserRequest>,
     ) -> Result<(pb::CreateUserResponse, Context), ConnectError> {
-        // #[connect_impl] inserts req.validate()? here automatically.
+        // #[connect_impl] validates the request here automatically.
         // Body only sees already-validated requests.
     }
 }

--- a/crates/protovalidate-buffa-macros/src/lib.rs
+++ b/crates/protovalidate-buffa-macros/src/lib.rs
@@ -1,10 +1,11 @@
 //! `#[connect_impl]` — inserts `req.validate()?` at the top of every Connect
 //! service handler method in an `impl` block whose request parameter is an
-//! `OwnedView<_>`. Single-site safety net: add it once to the service impl
-//! and every present-and-future handler is validated on entry.
+//! `OwnedView<_>` or `connectrpc::ServiceRequest<'_, _>`. Single-site safety
+//! net: add it once to the service impl and every present-and-future handler is
+//! validated on entry.
 //!
 //! Non-handler `async fn`s inside the same `impl` block are left alone
-//! (they lack an `OwnedView<_>` parameter, so the macro skips them).
+//! (they lack a recognized request parameter, so the macro skips them).
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -26,7 +27,7 @@ pub fn connect_impl(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     for impl_item in &mut item.items {
         if let ImplItem::Fn(f) = impl_item
-            && let Some(arg_ident) = find_owned_view_arg(&f.sig)
+            && let Some(arg_ident) = find_request_arg(&f.sig)
         {
             let pv_ident =
                 proc_macro2::Ident::new("__protovalidate_buffa_req_owned", arg_ident.span());
@@ -47,13 +48,14 @@ pub fn connect_impl(attr: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(quote! { #item })
 }
 
-/// Returns the ident of the first parameter whose type is a path ending in
-/// `OwnedView` (e.g. `OwnedView<pb::CreateFooRequestView<'static>>`).
-/// Non-handler methods that lack such a parameter return `None`.
-fn find_owned_view_arg(sig: &syn::Signature) -> Option<syn::Ident> {
+/// Returns the ident of the first request parameter whose type exposes
+/// `to_owned_message()`, such as `OwnedView<pb::CreateFooRequestView<'static>>`
+/// or `connectrpc::ServiceRequest<'_, pb::CreateFooRequest>`. Non-handler
+/// methods that lack such a parameter return `None`.
+fn find_request_arg(sig: &syn::Signature) -> Option<syn::Ident> {
     for arg in &sig.inputs {
         if let FnArg::Typed(PatType { pat, ty, .. }) = arg
-            && is_owned_view(ty)
+            && is_request_type(ty)
             && let syn::Pat::Ident(pat_ident) = pat.as_ref()
         {
             return Some(pat_ident.ident.clone());
@@ -62,11 +64,11 @@ fn find_owned_view_arg(sig: &syn::Signature) -> Option<syn::Ident> {
     None
 }
 
-fn is_owned_view(ty: &Type) -> bool {
+fn is_request_type(ty: &Type) -> bool {
     if let Type::Path(TypePath { path, .. }) = ty
         && let Some(last) = path.segments.last()
     {
-        return last.ident == "OwnedView";
+        return last.ident == "OwnedView" || last.ident == "ServiceRequest";
     }
     false
 }

--- a/crates/protovalidate-buffa/tests/connect_impl.rs
+++ b/crates/protovalidate-buffa/tests/connect_impl.rs
@@ -1,7 +1,7 @@
 //! Confirms `#[connect_impl]` injects `validate()` before user code. A
-//! fake service impl uses a mock trait and a mock View — the macro still
-//! inserts the decode + validate because it recognizes `OwnedView<_>` in
-//! the signature.
+//! fake service impls use mock traits and mock views — the macro still
+//! inserts the decode + validate because it recognizes `OwnedView<_>` and
+//! `ServiceRequest<'_, _>` in the signature.
 
 #![cfg(feature = "connect")]
 // `clippy::result_large_err` fires on the fake trait because
@@ -58,25 +58,55 @@ impl<T> std::ops::Deref for OwnedView<T> {
     }
 }
 
+struct ServiceRequest<'a, T>(&'a T);
+
+impl ServiceRequest<'_, FakeView> {
+    const fn to_owned_message(&self) -> FakeOwned {
+        self.0.to_owned_message()
+    }
+}
+
 trait FakeService {
     fn handle(&self, request: OwnedView<FakeView>) -> Result<(), ::connectrpc::ConnectError>;
 }
 
-struct Impl {
+trait FakeServiceRequestService {
+    fn handle(
+        &self,
+        request: ServiceRequest<'_, FakeView>,
+    ) -> Result<(), ::connectrpc::ConnectError>;
+}
+
+struct OwnedViewImpl {
+    called: Cell<bool>,
+}
+
+struct ServiceRequestImpl {
     called: Cell<bool>,
 }
 
 #[connect_impl]
-impl FakeService for Impl {
+impl FakeService for OwnedViewImpl {
     fn handle(&self, _request: OwnedView<FakeView>) -> Result<(), ::connectrpc::ConnectError> {
         self.called.set(true);
         Ok(())
     }
 }
 
+#[connect_impl]
+impl FakeServiceRequestService for ServiceRequestImpl {
+    fn handle(
+        &self,
+        _request: ServiceRequest<'_, FakeView>,
+    ) -> Result<(), ::connectrpc::ConnectError> {
+        self.called.set(true);
+        Ok(())
+    }
+}
+
 #[test]
-fn injects_validate_and_short_circuits_on_failure() {
-    let svc = Impl {
+fn injects_validate_for_owned_view_and_short_circuits_on_failure() {
+    let svc = OwnedViewImpl {
         called: Cell::new(false),
     };
     let err = svc
@@ -87,10 +117,31 @@ fn injects_validate_and_short_circuits_on_failure() {
 }
 
 #[test]
-fn injects_validate_and_runs_body_on_success() {
-    let svc = Impl {
+fn injects_validate_for_owned_view_and_runs_body_on_success() {
+    let svc = OwnedViewImpl {
         called: Cell::new(false),
     };
     svc.handle(OwnedView(FakeView { valid: true })).unwrap();
+    assert!(svc.called.get(), "body must run when validate passes");
+}
+
+#[test]
+fn injects_validate_for_service_request_and_short_circuits_on_failure() {
+    let svc = ServiceRequestImpl {
+        called: Cell::new(false),
+    };
+    let view = FakeView { valid: false };
+    let err = svc.handle(ServiceRequest(&view)).unwrap_err();
+    assert_eq!(err.code, ::connectrpc::ErrorCode::InvalidArgument);
+    assert!(!svc.called.get(), "body must not run when validate fails");
+}
+
+#[test]
+fn injects_validate_for_service_request_and_runs_body_on_success() {
+    let svc = ServiceRequestImpl {
+        called: Cell::new(false),
+    };
+    let view = FakeView { valid: true };
+    svc.handle(ServiceRequest(&view)).unwrap();
     assert!(svc.called.get(), "body must run when validate passes");
 }


### PR DESCRIPTION
## Summary

- teach `#[connect_impl]` to recognize Connect 0.7 `ServiceRequest<'_, Req>` handler parameters
- keep validation injection for the existing `OwnedView<_>` handler shape
- add regression coverage for both request forms and update the README example

## Root cause

The macro only matched parameter type paths ending in `OwnedView`. Connect 0.7 generated service impls now receive `connectrpc::ServiceRequest<'_, Req>`, so the macro skipped those handlers and no longer injected request validation.

## Validation

- `cargo test -p protovalidate-buffa --test connect_impl`
- `cargo fmt --all -- --check`
- `mise x aqua:protocolbuffers/protobuf/protoc@35.1 -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise x aqua:protocolbuffers/protobuf/protoc@35.1 -- cargo test --workspace --all-targets`
