### PR TITLE
build!: update buffa to 0.9.1 and connectrpc to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "buffa"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f29a40702df4b86ccd84211bfde8cee0bce6d0811450ade4a86a7d0958a23a"
+checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
 dependencies = [
  "bytes",
  "foldhash",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-build"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33217cabddfad99c0a54d42ddb7ca5b73fa492f7b16ddb621132ef51107556"
+checksum = "247d43740a4854a9c1b98a5931d6d67d8f8b41ffeb2a43ca008d460e79b1eb2c"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-codegen"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6681b562b18ea719622d0d12684e88ecbdca600d517557dc7bcef7704631e28"
+checksum = "2074a9c2f76b2ebe6af40f7bf67b6a19d6ce3663253ef2a55124dc93f38b230e"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-descriptor"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ed423c4ecec86d1500879ce42e7e5f6def01bc632985ac756c1fd723fa21fc"
+checksum = "964d735e0b06cb24fa15a68c5aa99549abcc7e0bbeb76298f2fec57912fb79c1"
 dependencies = [
  "buffa",
  "rustversion",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "connectrpc"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d1bbfc95ed1f4f31a027f5b97ff981be2617bc8a5c800fd6fcc701867bb97f"
+checksum = "85de144722d22eb03b7985136d8cd29b89d277a2df4ae0f53ef46488c467cbaf"
 dependencies = [
  "async-trait",
  "base64",
@@ -255,6 +255,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
+ "sync_wrapper",
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
@@ -952,9 +953,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smoothutf8"
-version = "0.1.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36358427d32ecdb1624616deed99eccfef0a167fe5bf40ddb51efe6980bc1ec8"
+checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
 dependencies = [
  "simdutf8",
 ]
@@ -1048,6 +1049,18 @@ checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Compared to reflection-based implementations, the codegen approach has two chara
 
 ## Compatibility
 
-This workspace currently targets **buffa 0.8**, **connectrpc 0.8**, and **Rust 1.88+** (edition 2024).
+This workspace currently targets **buffa 0.9.1**, **connectrpc 0.9**, and **Rust 1.88+** (edition 2024).
 
 The emitted validators reference buffa's generated-code shape directly (field placement, map and view types), so the plugin and your `buffa-build` output must agree on the buffa minor version. buffa is pre-1.0 and treats **minor bumps as breaking**, so upgrading buffa generally means upgrading this crate in lockstep.
 
-buffa 0.9 is intentionally not adopted yet: `connectrpc` 0.8 still depends on buffa `^0.8`, so moving this workspace to 0.9 would link two incompatible buffa versions and break the default `connect` feature for downstream handlers. This crate will move to buffa 0.9 once connectrpc does.
+The `connect` feature links `connectrpc`, which itself depends on buffa `^0.9.1` — so the buffa version here has to stay in step with connectrpc's, otherwise two incompatible buffa versions get linked and the default `connect` feature breaks for downstream handlers.
 
 ## Supported rules
 

--- a/crates/protoc-gen-protovalidate-buffa/Cargo.toml
+++ b/crates/protoc-gen-protovalidate-buffa/Cargo.toml
@@ -22,8 +22,8 @@ name = "protoc-gen-protovalidate-buffa"
 path = "src/main.rs"
 
 [dependencies]
-buffa = "0.8"
-buffa-codegen = "0.8"
+buffa = "0.9.1"
+buffa-codegen = "0.9.1"
 protovalidate-buffa-protos = { path = "../protovalidate-buffa-protos", version = "0.6.0" }
 proc-macro2 = "1"
 quote = "1"

--- a/crates/protovalidate-buffa-conformance/Cargo.toml
+++ b/crates/protovalidate-buffa-conformance/Cargo.toml
@@ -20,7 +20,7 @@ name = "protovalidate-buffa-conformance"
 path = "src/main.rs"
 
 [dependencies]
-buffa = "0.8"
+buffa = "0.9.1"
 protovalidate-buffa = { path = "../protovalidate-buffa", version = "0.6.0", default-features = false, features = ["tz"] }
 protovalidate-buffa-protos = { path = "../protovalidate-buffa-protos", version = "0.6.0" }
 anyhow = "1"
@@ -33,10 +33,10 @@ regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 [build-dependencies]
-buffa-build = "0.8"
+buffa-build = "0.9.1"
 protoc-gen-protovalidate-buffa = { path = "../protoc-gen-protovalidate-buffa", version = "0.6.0" }
-buffa = "0.8"
-buffa-codegen = "0.8"
+buffa = "0.9.1"
+buffa-codegen = "0.9.1"
 anyhow = "1"
 prettyplease = "0.3"
 syn = { version = "3", features = ["full"] }

--- a/crates/protovalidate-buffa-protos/Cargo.toml
+++ b/crates/protovalidate-buffa-protos/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-buffa = "0.8"
+buffa = "0.9.1"
 
 [build-dependencies]
-buffa-build = "0.8"
+buffa-build = "0.9.1"

--- a/crates/protovalidate-buffa/Cargo.toml
+++ b/crates/protovalidate-buffa/Cargo.toml
@@ -26,7 +26,7 @@ connect = ["dep:connectrpc"]
 tz = ["dep:chrono-tz"]
 
 [dependencies]
-buffa = "0.8"
+buffa = "0.9.1"
 protovalidate-buffa-macros = { path = "../protovalidate-buffa-macros", version = "0.4.0" }
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
@@ -35,6 +35,6 @@ uuid = "1"
 ulid = "3"
 ipnet = "2"
 fluent-uri = "0.4"
-connectrpc = { version = "0.8", default-features = false, optional = true }
+connectrpc = { version = "0.9", default-features = false, optional = true }
 percent-encoding = "2"
 http = "1"


### PR DESCRIPTION
Lifts the buffa 0.9 holdback from #23.

That upgrade pinned the workspace to buffa 0.8 because `connectrpc` 0.8 depended on buffa `^0.8`, so taking 0.9 would have linked two incompatible buffa versions and broken the default `connect` feature for downstream handlers. `connectrpc` 0.9.0 now depends on buffa `^0.9.1`, so the two agree and the holdback is moot.

- buffa, buffa-build, buffa-codegen 0.8 -> 0.9.1
- connectrpc 0.8 -> 0.9

No source changes were needed — unlike the 0.7 -> 0.8 bump (which moved generated map fields off `std::hash::RandomState`), buffa 0.9 did not move any generated-code shape the emitted validators depend on. Transitively the lockfile picks up smoothutf8 0.2 and tokio-macros.

The README `## Compatibility` holdback paragraph is rewritten as the standing constraint it actually is: the buffa version here has to track whatever `connectrpc` pins, in both directions.

## Verification

Because buffa treats minor bumps as breaking on generated-code shape, the meaningful gate is the upstream conformance suite run against buffa-build 0.9.1 codegen. CI does not run it, so it was run locally:

```
PASS (failed: 0, skipped: 0, passed: 2872, total: 2872)
```

Also clean:

- `cargo build --workspace --all-features`
- `cargo test --workspace --all-features` — 167 passed, 0 failed
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`