### PR TITLE
docs: credit Discussion authors in implementation PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,6 @@ Mathematic uses AI agents to maintain this repository and implement changes. Rev
 2. Wait for a Mathematic maintainer to review the proposal.
 3. If we accept it, a Mathematic maintainer or agent will implement the change and open a pull request.
 
+When Mathematic implements a proposal, we will link the implementation pull request to the Discussion and credit the proposal's original author.
+
 GitHub restricts pull request creation to Mathematic maintainers and repository collaborators with write, maintain, or admin access, plus authorized maintenance agents. If you do not have that access, use Discussions. We still welcome your ideas there.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See [`crates/protovalidate-buffa-conformance/README.md`](crates/protovalidate-bu
 
 ## Contributing
 
-Please [start a Discussion](../../discussions/new) before proposing a change. If we accept the proposal, a Mathematic maintainer or AI agent will implement it and open a pull request. GitHub restricts pull request creation to Mathematic maintainers and repository collaborators with write, maintain, or admin access, plus authorized maintenance agents. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
+Please [start a Discussion](../../discussions/new) before proposing a change. If we accept the proposal, a Mathematic maintainer or AI agent will implement it and open a pull request. When Mathematic implements a proposal, we will link the implementation pull request to the Discussion and credit the proposal's original author. GitHub restricts pull request creation to Mathematic maintainers and repository collaborators with write, maintain, or admin access, plus authorized maintenance agents. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
 
 ## License
 


### PR DESCRIPTION
Adds the attribution guarantee to README.md and CONTRIBUTING.md: implementation pull requests will link to the accepted Discussion and credit the proposal's original author.