### PR TITLE
feat: validate buffa view types

### DIFF
--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
@@ -25,9 +25,10 @@ use crate::{
 /// Returns `(statics, calls)` — statics go outside the impl block, calls go
 /// inside the `validate` body after field/oneof blocks.
 #[must_use]
-pub fn emit_message_level(
+pub(crate) fn emit_message_level(
     msg: &MessageValidators,
     schemas: &SchemaIndex,
+    shape: crate::emit::Shape,
 ) -> (Vec<TokenStream>, Vec<TokenStream>) {
     let statics = Vec::new();
     let mut calls = Vec::new();
@@ -111,7 +112,7 @@ pub fn emit_message_level(
             // runtime-error marker so the unsupported rule surfaces
             // clearly at validate-time.
             if let Some(native_call) =
-                try_emit_native_field_cel(f, rule, &fp, idx_lit, &field_ident, schemas)
+                try_emit_native_field_cel(f, rule, &fp, idx_lit, &field_ident, schemas, shape)
             {
                 calls.push(native_call);
                 continue;
@@ -200,6 +201,7 @@ pub fn emit_message_level(
                 &field_ident,
                 &predef_field_path,
                 &predef_rule_path,
+                shape,
             ) {
                 calls.push(native_call);
                 continue;
@@ -389,6 +391,7 @@ pub(crate) fn try_emit_native_field_cel(
     idx_lit: u64,
     field_ident: &syn::Ident,
     schemas: &SchemaIndex,
+    shape: crate::emit::Shape,
 ) -> Option<TokenStream> {
     // First, try the message-typed `this` binding for fields whose type is
     // a known sub-message (e.g., `optional Inner val = 1` with a CEL rule
@@ -398,7 +401,7 @@ pub(crate) fn try_emit_native_field_cel(
         return Some(out);
     }
     let this_ty = scalar_this_for_with(&f.field_type, Some(schemas))?;
-    let access = field_this_access(f, field_ident, &this_ty)?;
+    let access = field_this_access(f, field_ident, &this_ty, shape)?;
     let mut compiler = Compiler::new();
     compiler.bind(
         "this",
@@ -599,11 +602,16 @@ fn field_this_access(
     f: &FieldValidator,
     field_ident: &syn::Ident,
     cel_ty: &CelType,
+    shape: crate::emit::Shape,
 ) -> Option<TokenStream> {
     match &f.field_type {
         FieldKind::Optional(inner) => Some(match (cel_ty, inner.as_ref()) {
-            (CelType::Str { .. }, _) => quote! { __cel_inner.as_str() },
-            (CelType::Bytes { .. }, _) => quote! { __cel_inner.as_slice() },
+            (CelType::Str { .. }, _) => {
+                quote! { ::core::convert::AsRef::<str>::as_ref(__cel_inner) }
+            }
+            (CelType::Bytes { .. }, _) => {
+                quote! { ::core::convert::AsRef::<[u8]>::as_ref(__cel_inner) }
+            }
             (CelType::Int, FieldKind::Enum { .. }) => quote! {
                 ({
                     use ::buffa::Enumeration as _;
@@ -617,8 +625,12 @@ fn field_this_access(
             _ => return None,
         }),
         FieldKind::Wrapper(_) => Some(match cel_ty {
-            CelType::Str { .. } => quote! { __cel_inner.value.as_str() },
-            CelType::Bytes { .. } => quote! { __cel_inner.value.as_slice() },
+            CelType::Str { .. } => {
+                quote! { ::core::convert::AsRef::<str>::as_ref(&__cel_inner.value) }
+            }
+            CelType::Bytes { .. } => {
+                quote! { ::core::convert::AsRef::<[u8]>::as_ref(&__cel_inner.value) }
+            }
             CelType::Int => quote! { (__cel_inner.value as i64) },
             CelType::UInt => quote! { (__cel_inner.value as u64) },
             CelType::Double => quote! { (__cel_inner.value as f64) },
@@ -631,10 +643,14 @@ fn field_this_access(
                 self.#field_ident.to_i32() as i64
             })
         }),
-        FieldKind::String => Some(quote! { self.#field_ident.as_str() }),
-        FieldKind::Bytes => Some(quote! { self.#field_ident.as_slice() }),
-        FieldKind::Repeated(_) => Some(quote! { self.#field_ident.as_slice() }),
-        FieldKind::Map { .. } => Some(quote! { (&self.#field_ident) }),
+        FieldKind::String => {
+            Some(quote! { ::core::convert::AsRef::<str>::as_ref(&self.#field_ident) })
+        }
+        FieldKind::Bytes => {
+            Some(quote! { ::core::convert::AsRef::<[u8]>::as_ref(&self.#field_ident) })
+        }
+        FieldKind::Repeated(_) => Some(quote! { (&self.#field_ident) }),
+        FieldKind::Map { .. } => Some(shape.map_access(field_ident, f.field_number)),
         FieldKind::Float
         | FieldKind::Double
         | FieldKind::Int32
@@ -1144,10 +1160,11 @@ pub(crate) fn try_emit_native_predefined(
     field_ident: &syn::Ident,
     field_path: &TokenStream,
     rule_path: &TokenStream,
+    shape: crate::emit::Shape,
 ) -> Option<TokenStream> {
     let rule_const = rule.rule_const.as_ref()?;
     let this_ty = scalar_this_for(&f.field_type)?;
-    let access = field_this_access(f, field_ident, &this_ty)?;
+    let access = field_this_access(f, field_ident, &this_ty, shape)?;
     let mut compiler = Compiler::new();
     compiler.bind(
         "this",

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
@@ -2368,13 +2368,13 @@ impl<'a> Compiler<'a> {
                 let (tokens, ty) = match val_ty {
                     CelType::Str { .. } => (
                         quote! {
-                            ((#op_t).get(#key_lookup).map_or("", |__v| __v.as_str()))
+                            ((#op_t).get(#key_lookup).map_or("", ::core::convert::AsRef::<str>::as_ref))
                         },
                         CelType::Str { owned: false },
                     ),
                     CelType::Bytes { .. } => (
                         quote! {
-                            ((#op_t).get(#key_lookup).map_or(&[][..], |__v| __v.as_slice()))
+                            ((#op_t).get(#key_lookup).map_or(&[][..], ::core::convert::AsRef::<[u8]>::as_ref))
                         },
                         CelType::Bytes { owned: false },
                     ),
@@ -3832,8 +3832,10 @@ fn bytes_as_slice(c: &Compiled) -> TokenStream {
 /// comprehension iteration variable (a `&T` produced by `.iter()`).
 fn element_binding_expr(var_ident: &syn::Ident, elem_ty: &CelType) -> TokenStream {
     match elem_ty {
-        CelType::Str { .. } => quote! { (#var_ident.as_str()) },
-        CelType::Bytes { .. } => quote! { (#var_ident.as_slice()) },
+        CelType::Str { .. } => quote! { (::core::convert::AsRef::<str>::as_ref(#var_ident)) },
+        CelType::Bytes { .. } => {
+            quote! { (::core::convert::AsRef::<[u8]>::as_ref(#var_ident)) }
+        }
         CelType::Int => quote! {
             (::protovalidate_buffa::cel::CelScalar::cel_int(*#var_ident))
         },
@@ -3921,8 +3923,12 @@ fn select_message_field(
     let rust_ident = crate::emit::field_ident(&entry.rust_ident);
     let access = match &entry.kind {
         SchemaFieldKind::StringLike => match &entry.ty {
-            CelType::Str { .. } => quote! { (#operand.#rust_ident.as_str()) },
-            CelType::Bytes { .. } => quote! { (#operand.#rust_ident.as_slice()) },
+            CelType::Str { .. } => {
+                quote! { (::core::convert::AsRef::<str>::as_ref(&#operand.#rust_ident)) }
+            }
+            CelType::Bytes { .. } => {
+                quote! { (::core::convert::AsRef::<[u8]>::as_ref(&#operand.#rust_ident)) }
+            }
             _ => return Err(FallbackReason::new("schema StringLike with wrong CelType")),
         },
         SchemaFieldKind::Scalar => match &entry.ty {
@@ -3964,7 +3970,7 @@ fn select_message_field(
                 }
             }
         }
-        SchemaFieldKind::Repeated => quote! { (#operand.#rust_ident.as_slice()) },
+        SchemaFieldKind::Repeated => quote! { (&#operand.#rust_ident) },
         SchemaFieldKind::Wrapper => match &entry.ty {
             CelType::Int => {
                 quote! { (#operand.#rust_ident.as_option().map_or(0i64, |w| ::protovalidate_buffa::cel::CelScalar::cel_int(w.value))) }
@@ -3979,10 +3985,10 @@ fn select_message_field(
                 quote! { (#operand.#rust_ident.as_option().map_or(false, |w| w.value)) }
             }
             CelType::Str { .. } => {
-                quote! { (#operand.#rust_ident.as_option().map_or("", |w| w.value.as_str())) }
+                quote! { (#operand.#rust_ident.as_option().map_or("", |w| ::core::convert::AsRef::<str>::as_ref(&w.value))) }
             }
             CelType::Bytes { .. } => {
-                quote! { (#operand.#rust_ident.as_option().map_or(&[][..], |w| w.value.as_slice())) }
+                quote! { (#operand.#rust_ident.as_option().map_or(&[][..], |w| ::core::convert::AsRef::<[u8]>::as_ref(&w.value))) }
             }
             _ => {
                 return Err(FallbackReason::new(

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
@@ -26,9 +26,10 @@ use crate::scan::{
     clippy::too_many_lines,
     reason = "codegen helper — one branch per FieldKind; splitting hurts readability"
 )]
-pub fn emit(
+pub(crate) fn emit(
     field: &FieldValidator,
     schemas: &crate::emit::cel::SchemaIndex,
+    shape: crate::emit::Shape,
 ) -> Result<TokenStream> {
     if matches!(field.ignore, Ignore::Always) {
         return Ok(quote! {});
@@ -207,14 +208,12 @@ pub fn emit(
             if !inner_blocks.is_empty() {
                 match inner.as_ref() {
                     FieldKind::String => blocks.push(quote! {
-                        if let Some(v) = self.#accessor.as_ref() {
-                            let v: ::std::string::String = v.clone();
+                        if let Some(v) = self.#accessor.as_deref() {
                             #( #inner_blocks )*
                         }
                     }),
                     FieldKind::Bytes => blocks.push(quote! {
-                        if let Some(v) = self.#accessor.as_ref() {
-                            let v: ::std::vec::Vec<u8> = v.clone();
+                        if let Some(v) = self.#accessor.as_deref() {
                             #( #inner_blocks )*
                         }
                     }),
@@ -262,9 +261,10 @@ pub fn emit(
             }
         }
         FieldKind::Map { key, value } => {
+            let map = shape.map_access(&accessor, field.field_number);
             if let Some(m) = &field.standard.map {
                 blocks.push(crate::emit::repeated::emit_map(
-                    &accessor,
+                    &map,
                     name_lit,
                     field.field_number,
                     m,
@@ -284,7 +284,7 @@ pub fn emit(
                         crate::emit::repeated::kind_variant_to_subscript(kind_to_field_type(key))
                     {
                         blocks.push(quote! {
-                            for (key, value) in self.#accessor.iter() {
+                            for (key, value) in (#map).iter() {
                                 if let Err(sub) = value.validate() {
                                     violations.extend(sub.violations.into_iter().map(|mut v| {
                                         v.field.elements.insert(0, ::protovalidate_buffa::FieldPathElement {
@@ -374,21 +374,24 @@ pub fn emit(
                     let expected_lits = expected.iter().map(String::as_str);
                     let msg_str = format!("must equal paths [{}]", expected.join(", "));
                     blocks.push(quote! {
-                            if let Some(inner) = self.#accessor.as_option() {
-                                const EXPECTED: &[&str] = &[ #( #expected_lits ),* ];
-                                let actual: ::std::vec::Vec<&str> = inner.paths.iter().map(|s| s.as_str()).collect();
-                                let eq = actual.len() == EXPECTED.len()
-                                    && actual.iter().zip(EXPECTED.iter()).all(|(a, b)| a == b);
-                                if !eq {
-                                    violations.push(::protovalidate_buffa::Violation {
-                                        field: #fp_c, rule: #rule,
-                                        rule_id: ::std::borrow::Cow::Borrowed("field_mask.const"),
-                                        message: ::std::borrow::Cow::Borrowed(#msg_str),
-                                        for_key: false,
-                                    });
-                                }
+                        if let Some(inner) = self.#accessor.as_option() {
+                            const EXPECTED: &[&str] = &[ #( #expected_lits ),* ];
+                            let eq = inner.paths.len() == EXPECTED.len()
+                                && inner.paths.iter().zip(EXPECTED.iter().copied()).all(
+                                    |(actual, expected)| {
+                                        ::core::convert::AsRef::<str>::as_ref(actual) == expected
+                                    },
+                                );
+                            if !eq {
+                                violations.push(::protovalidate_buffa::Violation {
+                                    field: #fp_c, rule: #rule,
+                                    rule_id: ::std::borrow::Cow::Borrowed("field_mask.const"),
+                                    message: ::std::borrow::Cow::Borrowed(#msg_str),
+                                    for_key: false,
+                                });
                             }
-                        });
+                        }
+                    });
                 }
                 if !fm.in_set.is_empty() {
                     let fp_i = &fp_msg;
@@ -398,7 +401,7 @@ pub fn emit(
                             if let Some(inner) = self.#accessor.as_option() {
                                 const ALLOWED: &[&str] = &[ #( #allowed ),* ];
                                 let ok = inner.paths.iter().all(|p| {
-                                    ALLOWED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, p.as_str()))
+                                    ALLOWED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, ::core::convert::AsRef::<str>::as_ref(p)))
                                 });
                                 if !ok {
                                     violations.push(::protovalidate_buffa::Violation {
@@ -419,8 +422,9 @@ pub fn emit(
                             if let Some(inner) = self.#accessor.as_option() {
                                 const DENIED: &[&str] = &[ #( #denied ),* ];
                                 let bad = inner.paths.iter().any(|p| {
-                                    DENIED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, p.as_str())
-                                        || ::protovalidate_buffa::rules::string::fieldmask_covers(p.as_str(), c))
+                                    let p = ::core::convert::AsRef::<str>::as_ref(p);
+                                    DENIED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, p)
+                                        || ::protovalidate_buffa::rules::string::fieldmask_covers(p, c))
                                 });
                                 if bad {
                                     violations.push(::protovalidate_buffa::Violation {
@@ -445,7 +449,7 @@ pub fn emit(
                     blocks.push(quote! {
                         if let Some(inner) = self.#accessor.as_option() {
                             const ALLOWED: &[&str] = &[ #( #set ),* ];
-                            if !ALLOWED.iter().any(|s| *s == inner.type_url.as_str()) {
+                            if !ALLOWED.iter().any(|s| *s == ::core::convert::AsRef::<str>::as_ref(&inner.type_url)) {
                                 violations.push(::protovalidate_buffa::Violation {
                                     field: #field_path, rule: #rule,
                                     rule_id: ::std::borrow::Cow::Borrowed("any.in"),
@@ -463,7 +467,7 @@ pub fn emit(
                     blocks.push(quote! {
                         if let Some(inner) = self.#accessor.as_option() {
                             const DISALLOWED: &[&str] = &[ #( #set ),* ];
-                            if DISALLOWED.iter().any(|s| *s == inner.type_url.as_str()) {
+                            if DISALLOWED.iter().any(|s| *s == ::core::convert::AsRef::<str>::as_ref(&inner.type_url)) {
                                 violations.push(::protovalidate_buffa::Violation {
                                     field: #field_path2, rule: #rule,
                                     rule_id: ::std::borrow::Cow::Borrowed("any.not_in"),
@@ -489,9 +493,18 @@ pub fn emit(
             // not the inner scalar — so use a Message-typed field path.
             let inner_blocks = emit_wrapper_inner(name_lit, field.field_number, inner, field);
             if !inner_blocks.is_empty() {
+                let binding = match inner.as_ref() {
+                    FieldKind::String => quote! {
+                        let v = ::core::convert::AsRef::<str>::as_ref(&__wrapper_inner.value);
+                    },
+                    FieldKind::Bytes => quote! {
+                        let v = ::core::convert::AsRef::<[u8]>::as_ref(&__wrapper_inner.value);
+                    },
+                    _ => quote! { let v = __wrapper_inner.value.clone(); },
+                };
                 blocks.push(quote! {
                     if let Some(__wrapper_inner) = self.#accessor.as_option() {
-                        let v = __wrapper_inner.value.clone();
+                        #binding
                         #( #inner_blocks )*
                     }
                 });
@@ -1701,20 +1714,16 @@ fn emit_string(
         // header_value allows empty strings.
         let (fn_path, rule_id, empty_rule_id): (TokenStream, &str, Option<&str>) = match wkr {
             1 => (
-                quote! { |v: &::std::string::String| ::protovalidate_buffa::rules::string::is_header_name(v, #strict) },
+                quote! { |v: &str| ::protovalidate_buffa::rules::string::is_header_name(v, #strict) },
                 "string.well_known_regex.header_name",
                 Some("string.well_known_regex.header_name_empty"),
             ),
             2 => (
-                quote! { |v: &::std::string::String| ::protovalidate_buffa::rules::string::is_header_value(v, #strict) },
+                quote! { |v: &str| ::protovalidate_buffa::rules::string::is_header_value(v, #strict) },
                 "string.well_known_regex.header_value",
                 None,
             ),
-            _ => (
-                quote! { |_v: &::std::string::String| true },
-                "string.well_known_regex",
-                None,
-            ),
+            _ => (quote! { |_v: &str| true }, "string.well_known_regex", None),
         };
         let rid = rule_id.to_string();
         if let Some(re) = empty_rule_id {
@@ -1727,7 +1736,7 @@ fn emit_string(
                         message: ::std::borrow::Cow::Borrowed(""),
                         for_key: false,
                     });
-                } else if !(#fn_path)(&self.#accessor) {
+                } else if !(#fn_path)(::core::convert::AsRef::<str>::as_ref(&self.#accessor)) {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field_b, rule: #rule_b,
                         rule_id: ::std::borrow::Cow::Borrowed(#rid),
@@ -1740,7 +1749,9 @@ fn emit_string(
             let _ = field_a;
             let _ = rule_a;
             out.push(quote! {
-                if !self.#accessor.is_empty() && !(#fn_path)(&self.#accessor) {
+                if !self.#accessor.is_empty()
+                    && !(#fn_path)(::core::convert::AsRef::<str>::as_ref(&self.#accessor))
+                {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field_b, rule: #rule_b,
                         rule_id: ::std::borrow::Cow::Borrowed(#rid),
@@ -1759,7 +1770,7 @@ fn emit_string(
         out.push(quote! {
             {
                 const ALLOWED: &[&str] = &[ #( #set ),* ];
-                if !ALLOWED.iter().any(|candidate| *candidate == self.#accessor.as_str()) {
+                if !ALLOWED.iter().any(|candidate| *candidate == ::core::convert::AsRef::<str>::as_ref(&self.#accessor)) {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field, rule: #rule,
                         rule_id: ::std::borrow::Cow::Borrowed("string.in"),
@@ -1780,7 +1791,7 @@ fn emit_string(
         out.push(quote! {
             {
                 const DISALLOWED: &[&str] = &[ #( #set ),* ];
-                if DISALLOWED.iter().any(|candidate| *candidate == self.#accessor.as_str()) {
+                if DISALLOWED.iter().any(|candidate| *candidate == ::core::convert::AsRef::<str>::as_ref(&self.#accessor)) {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field, rule: #rule,
                         rule_id: ::std::borrow::Cow::Borrowed("string.not_in"),
@@ -1988,7 +1999,7 @@ fn emit_bytes_value(
     let mut out: Vec<TokenStream> = Vec::new();
     let fp = || bytes_field_path(name_lit, field_number);
     let value_len = quote! { #value.len() };
-    let value_slice = quote! { #value.as_slice() };
+    let value_slice = quote! { ::core::convert::AsRef::<[u8]>::as_ref(&(#value)) };
 
     // bytes.ip = 4 or 16 bytes; bytes.ipv4 = 4 bytes; bytes.ipv6 = 16 bytes.
     if b.ip == Some(true) {
@@ -4011,7 +4022,7 @@ pub(crate) fn emit_wrapper_inner(
                             1,
                             "String",
                             "string.const",
-                            quote! { &#v != #c },
+                            quote! { #v != #c },
                         );
                     }
                     if let Some(n) = s.min_len {
@@ -4085,7 +4096,7 @@ pub(crate) fn emit_wrapper_inner(
                             22,
                             "Bool",
                             "string.uuid",
-                            quote! { !::protovalidate_buffa::rules::string::is_uuid(&#v) },
+                            quote! { !::protovalidate_buffa::rules::string::is_uuid(#v) },
                         );
                     }
                 }
@@ -5784,7 +5795,7 @@ pub(crate) fn emit_string_checks_on(
         out.push(quote! {
             {
                 const ALLOWED: &[&str] = &[ #( #set ),* ];
-                if !ALLOWED.iter().any(|c| *c == #v.as_str()) {
+                if !ALLOWED.iter().any(|c| *c == ::core::convert::AsRef::<str>::as_ref(#v)) {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field, rule: #rule,
                         rule_id: ::std::borrow::Cow::Borrowed("string.in"),
@@ -5802,7 +5813,7 @@ pub(crate) fn emit_string_checks_on(
         out.push(quote! {
             {
                 const DISALLOWED: &[&str] = &[ #( #set ),* ];
-                if DISALLOWED.iter().any(|c| *c == #v.as_str()) {
+                if DISALLOWED.iter().any(|c| *c == ::core::convert::AsRef::<str>::as_ref(#v)) {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field, rule: #rule,
                         rule_id: ::std::borrow::Cow::Borrowed("string.not_in"),
@@ -5831,7 +5842,7 @@ pub(crate) fn emit_string_checks_on(
                     ::protovalidate_buffa::regex::Regex::new(#pat_str)
                         .expect("pattern regex compiled at code-gen time")
                 });
-                if !re.is_match(#v.as_str()) {
+                if !re.is_match(::core::convert::AsRef::<str>::as_ref(#v)) {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field, rule: #rule,
                         rule_id: ::std::borrow::Cow::Borrowed("string.pattern"),

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
@@ -31,6 +31,70 @@ pub mod field;
 pub mod oneof;
 pub mod repeated;
 
+/// Generated message representation targeted by a validation body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Shape {
+    Owned,
+    View,
+}
+
+impl Shape {
+    /// Expression exposing protobuf's canonical map semantics for this shape.
+    pub(crate) fn map_access(
+        self,
+        accessor: &proc_macro2::Ident,
+        field_number: i32,
+    ) -> TokenStream {
+        match self {
+            Self::Owned => quote! { (&self.#accessor) },
+            Self::View => {
+                let binding = canonical_map_ident(field_number);
+                quote! { (&#binding) }
+            }
+        }
+    }
+}
+
+fn canonical_map_ident(field_number: i32) -> proc_macro2::Ident {
+    quote::format_ident!("__pv_map_{field_number}")
+}
+
+fn needs_canonical_map(field: &crate::scan::FieldValidator) -> bool {
+    use crate::scan::{FieldKind, Ignore};
+
+    if matches!(field.ignore, Ignore::Always) {
+        return false;
+    }
+    let FieldKind::Map { value, .. } = &field.field_type else {
+        return false;
+    };
+    field.standard.map.is_some()
+        || !field.cel.is_empty()
+        || !field.standard.predefined.is_empty()
+        || matches!(
+            value.as_ref(),
+            FieldKind::Message { full_name } if !full_name.starts_with("google.protobuf.")
+        )
+}
+
+fn canonical_map_bindings(msg: &MessageValidators, shape: Shape) -> Vec<TokenStream> {
+    if shape == Shape::Owned {
+        return Vec::new();
+    }
+    msg.field_rules
+        .iter()
+        .filter(|field| needs_canonical_map(field))
+        .map(|field| {
+            let accessor = field_ident(&field.field_name);
+            let binding = canonical_map_ident(field.field_number);
+            quote! {
+                let #binding =
+                    ::protovalidate_buffa::__private::CanonicalMap::from_view(&self.#accessor);
+            }
+        })
+        .collect()
+}
+
 /// Build the Rust identifier that accesses a proto field (or oneof) on a
 /// buffa-generated struct.
 ///
@@ -327,7 +391,9 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
         })
         .collect();
     let rust_path_str = rust_segs.join("::");
-    let rust_path = syn::parse_str::<syn::Path>(&rust_path_str)?;
+    let rust_path = syn::parse_str::<syn::Type>(&rust_path_str)?;
+    let view_path =
+        syn::parse_str::<syn::Type>(&format!("__buffa::view::{rust_path_str}View<'_>"))?;
 
     // Fields listed in a `(buf.validate.message).oneof` get implicit
     // IGNORE_IF_ZERO_VALUE semantics: their rule checks only fire when the
@@ -337,61 +403,75 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
         .iter()
         .flat_map(|o| o.fields.iter().map(String::as_str))
         .collect();
-    let field_blocks: Vec<TokenStream> = msg
-        .field_rules
-        .iter()
-        .map(|f| {
-            let inner = field::emit(f, schemas)?;
-            if implicit_ignore.contains(f.field_name.as_str())
-                && !matches!(f.ignore, crate::scan::Ignore::Always)
-            {
-                let accessor = field_ident(&f.field_name);
-                let guard: Option<TokenStream> = match &f.field_type {
-                    crate::scan::FieldKind::String | crate::scan::FieldKind::Bytes => {
-                        Some(quote! { !self.#accessor.is_empty() })
+    let render_field_blocks = |shape| {
+        msg.field_rules
+            .iter()
+            .map(|f| {
+                let inner = field::emit(f, schemas, shape)?;
+                if implicit_ignore.contains(f.field_name.as_str())
+                    && !matches!(f.ignore, crate::scan::Ignore::Always)
+                {
+                    let accessor = field_ident(&f.field_name);
+                    let guard: Option<TokenStream> = match &f.field_type {
+                        crate::scan::FieldKind::String | crate::scan::FieldKind::Bytes => {
+                            Some(quote! { !self.#accessor.is_empty() })
+                        }
+                        crate::scan::FieldKind::Repeated(_)
+                        | crate::scan::FieldKind::Map { .. } => {
+                            Some(quote! { !self.#accessor.is_empty() })
+                        }
+                        crate::scan::FieldKind::Int32
+                        | crate::scan::FieldKind::Sint32
+                        | crate::scan::FieldKind::Sfixed32 => {
+                            Some(quote! { self.#accessor != 0i32 })
+                        }
+                        crate::scan::FieldKind::Int64
+                        | crate::scan::FieldKind::Sint64
+                        | crate::scan::FieldKind::Sfixed64 => {
+                            Some(quote! { self.#accessor != 0i64 })
+                        }
+                        crate::scan::FieldKind::Uint32 | crate::scan::FieldKind::Fixed32 => {
+                            Some(quote! { self.#accessor != 0u32 })
+                        }
+                        crate::scan::FieldKind::Uint64 | crate::scan::FieldKind::Fixed64 => {
+                            Some(quote! { self.#accessor != 0u64 })
+                        }
+                        crate::scan::FieldKind::Float => Some(quote! { self.#accessor != 0f32 }),
+                        crate::scan::FieldKind::Double => Some(quote! { self.#accessor != 0f64 }),
+                        crate::scan::FieldKind::Bool => Some(quote! { self.#accessor }),
+                        crate::scan::FieldKind::Enum { .. } => {
+                            Some(quote! { (self.#accessor as i32) != 0i32 })
+                        }
+                        crate::scan::FieldKind::Message { .. }
+                        | crate::scan::FieldKind::Wrapper(_) => {
+                            Some(quote! { self.#accessor.is_set() })
+                        }
+                        crate::scan::FieldKind::Optional(_) => {
+                            Some(quote! { self.#accessor.is_some() })
+                        }
+                    };
+                    if let Some(g) = guard {
+                        Ok(quote! { if #g { #inner } })
+                    } else {
+                        Ok(inner)
                     }
-                    crate::scan::FieldKind::Repeated(_) | crate::scan::FieldKind::Map { .. } => {
-                        Some(quote! { !self.#accessor.is_empty() })
-                    }
-                    crate::scan::FieldKind::Int32
-                    | crate::scan::FieldKind::Sint32
-                    | crate::scan::FieldKind::Sfixed32 => Some(quote! { self.#accessor != 0i32 }),
-                    crate::scan::FieldKind::Int64
-                    | crate::scan::FieldKind::Sint64
-                    | crate::scan::FieldKind::Sfixed64 => Some(quote! { self.#accessor != 0i64 }),
-                    crate::scan::FieldKind::Uint32 | crate::scan::FieldKind::Fixed32 => {
-                        Some(quote! { self.#accessor != 0u32 })
-                    }
-                    crate::scan::FieldKind::Uint64 | crate::scan::FieldKind::Fixed64 => {
-                        Some(quote! { self.#accessor != 0u64 })
-                    }
-                    crate::scan::FieldKind::Float => Some(quote! { self.#accessor != 0f32 }),
-                    crate::scan::FieldKind::Double => Some(quote! { self.#accessor != 0f64 }),
-                    crate::scan::FieldKind::Bool => Some(quote! { self.#accessor }),
-                    crate::scan::FieldKind::Enum { .. } => {
-                        Some(quote! { (self.#accessor as i32) != 0i32 })
-                    }
-                    crate::scan::FieldKind::Message { .. } | crate::scan::FieldKind::Wrapper(_) => {
-                        Some(quote! { self.#accessor.is_set() })
-                    }
-                    crate::scan::FieldKind::Optional(_) => {
-                        Some(quote! { self.#accessor.is_some() })
-                    }
-                };
-                if let Some(g) = guard {
-                    Ok(quote! { if #g { #inner } })
                 } else {
                     Ok(inner)
                 }
-            } else {
-                Ok(inner)
-            }
-        })
-        .collect::<Result<_>>()?;
+            })
+            .collect::<Result<Vec<TokenStream>>>()
+    };
+    let owned_field_blocks = render_field_blocks(Shape::Owned)?;
+    let view_field_blocks = render_field_blocks(Shape::View)?;
     let oneof_blocks: Vec<TokenStream> = msg
         .oneof_rules
         .iter()
         .map(oneof::emit)
+        .collect::<Result<_>>()?;
+    let view_oneof_blocks: Vec<TokenStream> = msg
+        .oneof_rules
+        .iter()
+        .map(oneof::emit_view)
         .collect::<Result<_>>()?;
 
     // `(buf.validate.message).oneof` — fields where at most one may be set.
@@ -401,24 +481,32 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
         .map(|spec| emit_message_oneof(msg, spec))
         .collect();
 
-    let (cel_statics, cel_calls) = cel::emit_message_level(msg, schemas);
+    let (cel_statics, owned_cel_calls) = cel::emit_message_level(msg, schemas, Shape::Owned);
+    let (_, view_cel_calls) = cel::emit_message_level(msg, schemas, Shape::View);
+    let owned_map_bindings = canonical_map_bindings(msg, Shape::Owned);
+    let view_map_bindings = canonical_map_bindings(msg, Shape::View);
 
     let allows = gen_allows();
     if let Some(reason) = &msg.compile_error {
-        return Ok(quote! {
-            #allows
-            impl ::protovalidate_buffa::Validate for #rust_path {
-                fn validate(
-                    &self,
-                ) -> ::core::result::Result<(), ::protovalidate_buffa::ValidationError> {
-                    Err(::protovalidate_buffa::ValidationError {
-                        compile_error: ::core::option::Option::Some(
-                            ::std::string::String::from(#reason),
-                        ),
-                        ..::core::default::Default::default()
-                    })
+        let impls = [&rust_path, &view_path].map(|rust_path| {
+            quote! {
+                #allows
+                impl ::protovalidate_buffa::Validate for #rust_path {
+                    fn validate(
+                        &self,
+                    ) -> ::core::result::Result<(), ::protovalidate_buffa::ValidationError> {
+                        Err(::protovalidate_buffa::ValidationError {
+                            compile_error: ::core::option::Option::Some(
+                                ::std::string::String::from(#reason),
+                            ),
+                            ..::core::default::Default::default()
+                        })
+                    }
                 }
             }
+        });
+        return Ok(quote! {
+            #( #impls )*
         });
     }
     // Wrap each static + impl in the same outer allow set.
@@ -426,55 +514,70 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
         .into_iter()
         .map(|s| quote! { #allows #s })
         .collect();
-    Ok(quote! {
-        #( #statics_with_allows )*
-        #allows
-        impl ::protovalidate_buffa::Validate for #rust_path {
-            fn validate(
-                &self,
-            ) -> ::core::result::Result<(), ::protovalidate_buffa::ValidationError> {
-                let mut violations: ::std::vec::Vec<::protovalidate_buffa::Violation> =
-                    ::std::vec::Vec::new();
-                #( #field_blocks )*
-                #( #oneof_blocks )*
-                #( #message_oneof_blocks )*
-                #( #cel_calls )*
-                // Lift any `__cel_runtime_error__` marker violations to the
-                // typed `runtime_error` field so callers can pattern-match
-                // instead of sniffing `rule_id` strings.
-                let (rt_violation, violations): (
-                    ::std::option::Option<::protovalidate_buffa::Violation>,
-                    ::std::vec::Vec<::protovalidate_buffa::Violation>,
-                ) = {
-                    let mut rt = None;
-                    let mut rest = ::std::vec::Vec::with_capacity(violations.len());
-                    for v in violations {
-                        if rt.is_none() && v.rule_id == "__cel_runtime_error__" {
-                            rt = Some(v);
-                        } else {
-                            rest.push(v);
-                        }
+    let render_impl = |rust_path: &syn::Type,
+                       map_bindings: &[TokenStream],
+                       field_blocks: &[TokenStream],
+                       oneof_blocks: &[TokenStream],
+                       cel_calls: &[TokenStream]| {
+        quote! {
+            #allows
+            impl ::protovalidate_buffa::Validate for #rust_path {
+                fn validate(
+                    &self,
+                ) -> ::core::result::Result<(), ::protovalidate_buffa::ValidationError> {
+                    #( #map_bindings )*
+                    let mut violations: ::std::vec::Vec<::protovalidate_buffa::Violation> =
+                        ::std::vec::Vec::new();
+                    #( #field_blocks )*
+                    #( #oneof_blocks )*
+                    #( #message_oneof_blocks )*
+                    #( #cel_calls )*
+                    // Lift any `__cel_runtime_error__` marker violation to the
+                    // typed `runtime_error` field so callers can pattern-match
+                    // instead of sniffing `rule_id` strings.
+                    if let Some(index) = violations
+                        .iter()
+                        .position(|v| v.rule_id == "__cel_runtime_error__")
+                    {
+                        let v = violations.swap_remove(index);
+                        return ::core::result::Result::Err(
+                            ::protovalidate_buffa::ValidationError {
+                                runtime_error: ::core::option::Option::Some(v.message.into_owned()),
+                                ..::core::default::Default::default()
+                            },
+                        );
                     }
-                    (rt, rest)
-                };
-                if let Some(v) = rt_violation {
-                    return ::core::result::Result::Err(
-                        ::protovalidate_buffa::ValidationError {
-                            runtime_error: ::core::option::Option::Some(v.message.into_owned()),
+                    if violations.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(::protovalidate_buffa::ValidationError {
+                            violations,
                             ..::core::default::Default::default()
-                        },
-                    );
-                }
-                if violations.is_empty() {
-                    Ok(())
-                } else {
-                    Err(::protovalidate_buffa::ValidationError {
-                        violations,
-                        ..::core::default::Default::default()
-                    })
+                        })
+                    }
                 }
             }
         }
+    };
+    let impls = [
+        render_impl(
+            &rust_path,
+            &owned_map_bindings,
+            &owned_field_blocks,
+            &oneof_blocks,
+            &owned_cel_calls,
+        ),
+        render_impl(
+            &view_path,
+            &view_map_bindings,
+            &view_field_blocks,
+            &view_oneof_blocks,
+            &view_cel_calls,
+        ),
+    ];
+    Ok(quote! {
+        #( #statics_with_allows )*
+        #( #impls )*
     })
 }
 

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
@@ -6,6 +6,12 @@ use quote::{format_ident, quote};
 
 use crate::scan::{FieldKind, FieldValidator, OneofValidator};
 
+#[derive(Clone, Copy)]
+enum Representation {
+    Owned,
+    View,
+}
+
 /// Emit the validation snippet for a single oneof.
 ///
 /// Generates a `match &self.<oneof>` block that:
@@ -19,6 +25,14 @@ use crate::scan::{FieldKind, FieldValidator, OneofValidator};
 /// to a local Rust path. (Field/oneof names are escaped via
 /// [`crate::emit::field_ident`], which is infallible.)
 pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
+    emit_for(v, Representation::Owned)
+}
+
+pub(crate) fn emit_view(v: &OneofValidator) -> Result<TokenStream> {
+    emit_for(v, Representation::View)
+}
+
+fn emit_for(v: &OneofValidator, representation: Representation) -> Result<TokenStream> {
     let has_required = v.required;
     // If nothing to emit at all, skip.
     let has_variant_rules = v.fields.iter().any(has_field_rules);
@@ -36,6 +50,10 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
     // down to the per-variant emitters.
     let module_ident = crate::emit::field_ident(&to_snake_case(&v.parent_msg_name));
     let oneof_enum_ident = crate::emit::field_ident(&to_pascal_case(&v.name));
+    let oneof_root = match representation {
+        Representation::Owned => quote! { __buffa::oneof },
+        Representation::View => quote! { __buffa::view::oneof },
+    };
 
     let none_arm = if has_required {
         quote! {
@@ -71,7 +89,7 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
         .fields
         .iter()
         .filter(|f| has_field_rules(f))
-        .map(|f| emit_variant_arm(f, &module_ident, &oneof_enum_ident))
+        .map(|f| emit_variant_arm(f, &oneof_root, &module_ident, &oneof_enum_ident))
         .collect::<Result<Vec<_>>>()?
         .into_iter()
         .filter(|ts| !ts.is_empty())
@@ -79,7 +97,7 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
 
     // Compute required_variant_blocks early so they survive all early-return paths.
     let required_variant_blocks =
-        emit_required_variant_blocks(v, &accessor, &module_ident, &oneof_enum_ident);
+        emit_required_variant_blocks(v, &accessor, &oneof_root, &module_ident, &oneof_enum_ident);
 
     // If no variant has rules, we only need the None check (already handled above).
     if some_arms.is_empty() && !has_required && !has_required_variants {
@@ -142,6 +160,7 @@ pub fn emit(v: &OneofValidator) -> Result<TokenStream> {
 fn emit_required_variant_blocks(
     v: &OneofValidator,
     accessor: &syn::Ident,
+    oneof_root: &TokenStream,
     module_ident: &syn::Ident,
     oneof_enum_ident: &syn::Ident,
 ) -> Vec<TokenStream> {
@@ -178,7 +197,7 @@ fn emit_required_variant_blocks(
             _ => quote!(Message),
         };
         out.push(quote! {
-            if !matches!(&self.#accessor, Some(__buffa::oneof::#module_ident::#oneof_enum_ident::#variant_ident(_))) {
+            if !matches!(&self.#accessor, Some(#oneof_root::#module_ident::#oneof_enum_ident::#variant_ident(_))) {
                 violations.push(::protovalidate_buffa::Violation {
                     field: ::protovalidate_buffa::FieldPath {
                         elements: ::std::vec![
@@ -239,6 +258,7 @@ fn has_field_rules(f: &FieldValidator) -> bool {
 /// Emit a `Some(Variant(v)) => { ... }` match arm for a single oneof field.
 fn emit_variant_arm(
     f: &FieldValidator,
+    oneof_root: &TokenStream,
     module_ident: &syn::Ident,
     oneof_enum_ident: &syn::Ident,
 ) -> Result<TokenStream> {
@@ -343,9 +363,18 @@ fn emit_variant_arm(
             let inner_checks =
                 crate::emit::field::emit_wrapper_inner(name_lit, f.field_number, inner, f);
             if !inner_checks.is_empty() {
+                let binding = match inner.as_ref() {
+                    FieldKind::String => quote! {
+                        let v = ::core::convert::AsRef::<str>::as_ref(&v.value);
+                    },
+                    FieldKind::Bytes => quote! {
+                        let v = ::core::convert::AsRef::<[u8]>::as_ref(&v.value);
+                    },
+                    _ => quote! { let v = v.value.clone(); },
+                };
                 checks.push(quote! {
                     {
-                        let v = v.value.clone();
+                        #binding
                         #( #inner_checks )*
                     }
                 });
@@ -383,14 +412,14 @@ fn emit_variant_arm(
     );
     if needs_copy_deref {
         Ok(quote! {
-            Some(__buffa::oneof::#module_ident::#oneof_enum_ident::#variant_ident(__oneof_val)) => {
+            Some(#oneof_root::#module_ident::#oneof_enum_ident::#variant_ident(__oneof_val)) => {
                 let #val_ident = *__oneof_val;
                 #( #checks )*
             }
         })
     } else {
         Ok(quote! {
-            Some(__buffa::oneof::#module_ident::#oneof_enum_ident::#variant_ident(#val_ident)) => {
+            Some(#oneof_root::#module_ident::#oneof_enum_ident::#variant_ident(#val_ident)) => {
                 #( #checks )*
             }
         })
@@ -453,7 +482,7 @@ fn emit_oneof_wkt_checks(
             out.push(quote! {
                 {
                     const ALLOWED: &[&str] = &[ #( #set ),* ];
-                    if !ALLOWED.iter().any(|s| *s == #val_ident.type_url.as_str()) {
+                    if !ALLOWED.iter().any(|s| *s == ::core::convert::AsRef::<str>::as_ref(&#val_ident.type_url)) {
                         violations.push(::protovalidate_buffa::Violation {
                             field: #field,
                             rule: #rule,
@@ -472,7 +501,7 @@ fn emit_oneof_wkt_checks(
             out.push(quote! {
                 {
                     const DISALLOWED: &[&str] = &[ #( #set ),* ];
-                    if DISALLOWED.iter().any(|s| *s == #val_ident.type_url.as_str()) {
+                    if DISALLOWED.iter().any(|s| *s == ::core::convert::AsRef::<str>::as_ref(&#val_ident.type_url)) {
                         violations.push(::protovalidate_buffa::Violation {
                             field: #field,
                             rule: #rule,
@@ -497,9 +526,12 @@ fn emit_oneof_wkt_checks(
             out.push(quote! {
                 {
                     const EXPECTED: &[&str] = &[ #( #expected_lits ),* ];
-                    let actual: ::std::vec::Vec<&str> = #val_ident.paths.iter().map(|s| s.as_str()).collect();
-                    let eq = actual.len() == EXPECTED.len()
-                        && actual.iter().zip(EXPECTED.iter()).all(|(a, b)| a == b);
+                    let eq = #val_ident.paths.len() == EXPECTED.len()
+                        && #val_ident.paths.iter().zip(EXPECTED.iter().copied()).all(
+                            |(actual, expected)| {
+                                ::core::convert::AsRef::<str>::as_ref(actual) == expected
+                            },
+                        );
                     if !eq {
                         violations.push(::protovalidate_buffa::Violation {
                             field: #field,
@@ -520,7 +552,7 @@ fn emit_oneof_wkt_checks(
                 {
                     const ALLOWED: &[&str] = &[ #( #allowed ),* ];
                     let ok = #val_ident.paths.iter().all(|p| {
-                        ALLOWED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, p.as_str()))
+                        ALLOWED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, ::core::convert::AsRef::<str>::as_ref(p)))
                     });
                     if !ok {
                         violations.push(::protovalidate_buffa::Violation {
@@ -542,8 +574,9 @@ fn emit_oneof_wkt_checks(
                 {
                     const DENIED: &[&str] = &[ #( #denied ),* ];
                     let bad = #val_ident.paths.iter().any(|p| {
-                        DENIED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, p.as_str())
-                            || ::protovalidate_buffa::rules::string::fieldmask_covers(p.as_str(), c))
+                        let p = ::core::convert::AsRef::<str>::as_ref(p);
+                        DENIED.iter().any(|c| ::protovalidate_buffa::rules::string::fieldmask_covers(c, p)
+                            || ::protovalidate_buffa::rules::string::fieldmask_covers(p, c))
                     });
                     if bad {
                         violations.push(::protovalidate_buffa::Violation {

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/repeated.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/repeated.rs
@@ -297,7 +297,7 @@ fn emit_map_kv_checks(
                     out.push(quote! {
                         {
                             const ALLOWED: &[&str] = &[ #( #set ),* ];
-                            if !ALLOWED.iter().any(|c| *c == #elem_ident.as_str()) {
+                            if !ALLOWED.iter().any(|c| *c == ::core::convert::AsRef::<str>::as_ref(#elem_ident)) {
                                 violations.push(::protovalidate_buffa::Violation {
                                     field: #fp, rule: #rule,
                                     rule_id: ::std::borrow::Cow::Borrowed("string.in"),
@@ -359,9 +359,11 @@ pub(crate) fn kind_variant_to_subscript(kind_variant: &str) -> Option<TokenStrea
             Some(quote! { ::protovalidate_buffa::Subscript::UintKey(u64::from(*key)) })
         }
         "Uint64" | "Fixed64" => Some(quote! { ::protovalidate_buffa::Subscript::UintKey(*key) }),
-        "String" => Some(
-            quote! { ::protovalidate_buffa::Subscript::StringKey(::std::borrow::Cow::Owned(key.clone())) },
-        ),
+        "String" => Some(quote! {
+            ::protovalidate_buffa::Subscript::StringKey(::std::borrow::Cow::Owned(
+                ::core::convert::AsRef::<str>::as_ref(key).to_owned()
+            ))
+        }),
         _ => None,
     }
 }
@@ -947,7 +949,7 @@ fn emit_repeated_items_checks(
                     out.push(quote! {
                         {
                             const ALLOWED: &[&str] = &[ #( #set ),* ];
-                            if !ALLOWED.iter().any(|c| *c == #elem_ident.as_str()) {
+                            if !ALLOWED.iter().any(|c| *c == ::core::convert::AsRef::<str>::as_ref(#elem_ident)) {
                                 violations.push(::protovalidate_buffa::Violation {
                                     field: #fp, rule: #rule,
                                     rule_id: ::std::borrow::Cow::Borrowed("string.in"),
@@ -965,7 +967,7 @@ fn emit_repeated_items_checks(
                     out.push(quote! {
                         {
                             const DISALLOWED: &[&str] = &[ #( #set ),* ];
-                            if DISALLOWED.iter().any(|c| *c == #elem_ident.as_str()) {
+                            if DISALLOWED.iter().any(|c| *c == ::core::convert::AsRef::<str>::as_ref(#elem_ident)) {
                                 violations.push(::protovalidate_buffa::Violation {
                                     field: #fp, rule: #rule,
                                     rule_id: ::std::borrow::Cow::Borrowed("string.not_in"),
@@ -1234,11 +1236,8 @@ pub fn emit_repeated(
         let rule = repeated_rule_path_ty("unique", 3, "Bool");
         out.push(quote! {
             {
-                let mut seen: ::std::collections::HashSet<_> = ::std::collections::HashSet::new();
-                let mut dup = false;
-                for item in self.#accessor.iter() {
-                    if !seen.insert(item) { dup = true; break; }
-                }
+                let mut seen = ::std::collections::HashSet::with_capacity(self.#accessor.len());
+                let dup = self.#accessor.iter().any(|item| !seen.insert(item));
                 if dup {
                     violations.push(::protovalidate_buffa::Violation {
                         field: #field, rule: #rule,
@@ -1527,7 +1526,7 @@ pub fn emit_repeated(
                 out.push(quote! {
                     for (idx, elem) in self.#accessor.iter().enumerate() {
                         const ALLOWED: &[&str] = &[ #( #set ),* ];
-                        if !ALLOWED.iter().any(|s| *s == elem.type_url.as_str()) {
+                        if !ALLOWED.iter().any(|s| *s == ::core::convert::AsRef::<str>::as_ref(&elem.type_url)) {
                             violations.push(::protovalidate_buffa::Violation {
                                 field: ::protovalidate_buffa::FieldPath {
                                     elements: ::std::vec![::protovalidate_buffa::FieldPathElement {
@@ -1561,7 +1560,7 @@ pub fn emit_repeated(
                 out.push(quote! {
                     for (idx, elem) in self.#accessor.iter().enumerate() {
                         const DENIED: &[&str] = &[ #( #set ),* ];
-                        if DENIED.iter().any(|s| *s == elem.type_url.as_str()) {
+                        if DENIED.iter().any(|s| *s == ::core::convert::AsRef::<str>::as_ref(&elem.type_url)) {
                             violations.push(::protovalidate_buffa::Violation {
                                 field: ::protovalidate_buffa::FieldPath {
                                     elements: ::std::vec![::protovalidate_buffa::FieldPathElement {
@@ -1635,8 +1634,8 @@ pub fn emit_repeated(
             // Element access expression for scalar element kinds. Wrapper
             // elements yield `(*elem).value` which still satisfies CelScalar.
             let elem_access: Option<TokenStream> = match element_kind {
-                FieldKind::String => Some(quote! { elem.as_str() }),
-                FieldKind::Bytes => Some(quote! { elem.as_slice() }),
+                FieldKind::String => Some(quote! { ::core::convert::AsRef::<str>::as_ref(elem) }),
+                FieldKind::Bytes => Some(quote! { ::core::convert::AsRef::<[u8]>::as_ref(elem) }),
                 FieldKind::Bool => Some(quote! { (*elem) }),
                 FieldKind::Float
                 | FieldKind::Double
@@ -1652,10 +1651,10 @@ pub fn emit_repeated(
                 | FieldKind::Fixed64
                 | FieldKind::Enum { .. } => Some(quote! { (*elem) }),
                 FieldKind::Message { full_name } if full_name == "google.protobuf.StringValue" => {
-                    Some(quote! { elem.value.as_str() })
+                    Some(quote! { ::core::convert::AsRef::<str>::as_ref(&elem.value) })
                 }
                 FieldKind::Message { full_name } if full_name == "google.protobuf.BytesValue" => {
-                    Some(quote! { elem.value.as_slice() })
+                    Some(quote! { ::core::convert::AsRef::<[u8]>::as_ref(&elem.value) })
                 }
                 FieldKind::Message { full_name }
                     if full_name.starts_with("google.protobuf.")
@@ -1801,8 +1800,8 @@ pub fn emit_repeated(
             };
             // Native path: bind `this` to the element value and transpile.
             let elem_access = match element_kind {
-                FieldKind::String => Some(quote! { elem.as_str() }),
-                FieldKind::Bytes => Some(quote! { elem.as_slice() }),
+                FieldKind::String => Some(quote! { ::core::convert::AsRef::<str>::as_ref(elem) }),
+                FieldKind::Bytes => Some(quote! { ::core::convert::AsRef::<[u8]>::as_ref(elem) }),
                 FieldKind::Bool => Some(quote! { (*elem) }),
                 FieldKind::Float
                 | FieldKind::Double
@@ -1894,7 +1893,7 @@ pub fn emit_repeated(
 /// practice proto size bounds are small non-negative integers, so this
 /// invariant always holds.
 pub fn emit_map(
-    accessor: &syn::Ident,
+    map: &TokenStream,
     name_lit: &str,
     field_number: i32,
     spec: &MapStandard,
@@ -1910,13 +1909,13 @@ pub fn emit_map(
         let field = fp();
         let rule = map_rule_path("min_pairs", 1);
         out.push(quote! {
-            if self.#accessor.len() < #min_usize {
+            if (#map).len() < #min_usize {
                 violations.push(::protovalidate_buffa::Violation {
                     field: #field, rule: #rule,
                     rule_id: ::std::borrow::Cow::Borrowed("map.min_pairs"),
                     message: ::std::borrow::Cow::Owned(::std::format!(
                         "map must contain at least {} pairs (got {})",
-                        #min_usize, self.#accessor.len()
+                        #min_usize, (#map).len()
                     )),
                     for_key: false,
                 });
@@ -1929,13 +1928,13 @@ pub fn emit_map(
         let field = fp();
         let rule = map_rule_path("max_pairs", 2);
         out.push(quote! {
-            if self.#accessor.len() > #max_usize {
+            if (#map).len() > #max_usize {
                 violations.push(::protovalidate_buffa::Violation {
                     field: #field, rule: #rule,
                     rule_id: ::std::borrow::Cow::Borrowed("map.max_pairs"),
                     message: ::std::borrow::Cow::Owned(::std::format!(
                         "map must contain at most {} pairs (got {})",
-                        #max_usize, self.#accessor.len()
+                        #max_usize, (#map).len()
                     )),
                     for_key: false,
                 });
@@ -2051,7 +2050,7 @@ pub fn emit_map(
             |g| quote! { if #g { #( #val_checks )* } },
         );
         out.push(quote! {
-            for (key, value) in self.#accessor.iter() {
+            for (key, value) in (#map).iter() {
                 #key_block
                 #val_block
             }
@@ -2104,8 +2103,12 @@ pub fn emit_map(
                 }
             };
             let access = match target_kind {
-                FieldKind::String => Some(quote! { #value_ident.as_str() }),
-                FieldKind::Bytes => Some(quote! { #value_ident.as_slice() }),
+                FieldKind::String => {
+                    Some(quote! { ::core::convert::AsRef::<str>::as_ref(#value_ident) })
+                }
+                FieldKind::Bytes => {
+                    Some(quote! { ::core::convert::AsRef::<[u8]>::as_ref(#value_ident) })
+                }
                 FieldKind::Bool => Some(quote! { (*#value_ident) }),
                 FieldKind::Float
                 | FieldKind::Double
@@ -2132,7 +2135,7 @@ pub fn emit_map(
             });
             if let Some(check) = native {
                 out.push(quote! {
-                    for (key, value) in self.#accessor.iter() {
+                    for (key, value) in (#map).iter() {
                         #check
                     }
                 });
@@ -2167,7 +2170,7 @@ pub fn emit_map(
             let kt = format_ident!("{}", crate::emit::field::kind_to_field_type(key_kind));
             let vt = format_ident!("{}", crate::emit::field::kind_to_field_type(value_kind));
             out.push(quote! {
-                for (key, value) in self.#accessor.iter() {
+                for (key, value) in (#map).iter() {
                     if let Err(sub) = value.validate() {
                         violations.extend(sub.violations.into_iter().map(|mut v| {
                             v.field.elements.insert(0, ::protovalidate_buffa::FieldPathElement {
@@ -2220,7 +2223,7 @@ fn emit_scalar_checks(
                     out.push(quote! {
                         {
                             const ALLOWED: &[&str] = &[ #( #set ),* ];
-                            if !ALLOWED.iter().any(|c| *c == #elem_ident.as_str()) {
+                            if !ALLOWED.iter().any(|c| *c == ::core::convert::AsRef::<str>::as_ref(#elem_ident)) {
                                 violations.push(::protovalidate_buffa::Violation {
                                     field: ::protovalidate_buffa::field_path!(#field_name_lit),
                                     rule: ::protovalidate_buffa::field_path!("string", "in"),
@@ -2237,7 +2240,7 @@ fn emit_scalar_checks(
                     out.push(quote! {
                         {
                             const DISALLOWED: &[&str] = &[ #( #set ),* ];
-                            if DISALLOWED.iter().any(|c| *c == #elem_ident.as_str()) {
+                            if DISALLOWED.iter().any(|c| *c == ::core::convert::AsRef::<str>::as_ref(#elem_ident)) {
                                 violations.push(::protovalidate_buffa::Violation {
                                     field: ::protovalidate_buffa::field_path!(#field_name_lit),
                                     rule: ::protovalidate_buffa::field_path!("string", "not_in"),

--- a/crates/protoc-gen-protovalidate-buffa/tests/emit_view_types.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/emit_view_types.rs
@@ -1,0 +1,27 @@
+#![warn(rust_2018_idioms)]
+
+use protoc_gen_protovalidate_buffa::{emit::render, scan::MessageValidators};
+
+#[test]
+fn nested_message_emits_owned_and_view_validators() {
+    let files = render(&[MessageValidators {
+        proto_name: "test.v1.Outer.Nested".to_string(),
+        package: "test.v1".to_string(),
+        source_file: "test/v1/nested.proto".to_string(),
+        message_cel: Vec::new(),
+        message_oneofs: Vec::new(),
+        field_rules: Vec::new(),
+        oneof_rules: Vec::new(),
+        compile_error: None,
+    }])
+    .expect("render must succeed");
+    let source = files
+        .into_iter()
+        .filter_map(|file| file.content)
+        .collect::<String>();
+
+    assert!(source.contains("Validate for outer::Nested"));
+    assert!(source.contains("Validate for __buffa::view::outer::NestedView<'_>"));
+    assert_eq!(source.matches("let mut violations").count(), 2);
+    assert!(!source.contains("to_owned_message"));
+}

--- a/crates/protoc-gen-protovalidate-buffa/tests/optional_string_pattern.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/optional_string_pattern.rs
@@ -1,11 +1,10 @@
 //! Regression test for `optional string` (explicit presence) and oneof string
 //! members carrying a `string.pattern` rule.
 //!
-//! `emit_string_checks_on` is shared between the explicit-presence path (which
-//! binds `v` as an owned `String`) and oneof members (which bind `&String`).
-//! The `pattern` check passes `v` to `Regex::is_match`, which takes `&str`, but
-//! an owned `String` does not coerce in argument position. These tests pin that
-//! the emitted check borrows via `v.as_str()`, so both paths compile. See
+//! `emit_string_checks_on` is shared between owned messages and borrowed views.
+//! The `pattern` check passes `v` to `Regex::is_match`, which takes `&str`.
+//! These tests pin that the emitted check borrows via `AsRef`, so both
+//! representations compile without cloning. See
 //! `emit_string_checks_on` in `src/emit/field.rs` for why this matters.
 
 use protoc_gen_protovalidate_buffa::emit::render;
@@ -62,20 +61,15 @@ fn message(
     }
 }
 
-/// The emitted `pattern` check must borrow the value (`v.as_str()`); passing an
-/// owned `String` to `is_match` would fail to compile.
+/// The emitted `pattern` check must borrow the value through `AsRef`.
 fn assert_pattern_borrows(src: &str) {
     assert!(
-        src.contains("is_match(v.as_str())"),
-        "pattern check must borrow the value (`v.as_str()`); generated source was:\n{src}"
-    );
-    assert!(
-        !src.contains("is_match(v)"),
-        "pattern check must not pass an owned `String` to `is_match`; generated source was:\n{src}"
+        src.contains("is_match(::core::convert::AsRef::<str>::as_ref(v))"),
+        "pattern check must borrow the value through `AsRef`; generated source was:\n{src}"
     );
 }
 
-/// An `optional string` field binds `v` as an owned `String`.
+/// An `optional string` field borrows its inner value.
 #[test]
 fn optional_string_pattern_borrows_value() {
     let f = string_field_with_pattern(FieldKind::Optional(Box::new(FieldKind::String)));
@@ -83,8 +77,7 @@ fn optional_string_pattern_borrows_value() {
     assert_pattern_borrows(&src);
 }
 
-/// A oneof string member binds `v` as a `&String`; the same `as_str()` borrow
-/// must keep this path compiling.
+/// A oneof string member uses the same representation-neutral borrow.
 #[test]
 fn oneof_string_pattern_borrows_value() {
     let mut member = string_field_with_pattern(FieldKind::String);

--- a/crates/protovalidate-buffa-conformance/tests/view_allocations.rs
+++ b/crates/protovalidate-buffa-conformance/tests/view_allocations.rs
@@ -1,0 +1,166 @@
+#![warn(rust_2018_idioms)]
+#![allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    dead_code,
+    elided_lifetimes_in_paths,
+    non_camel_case_types,
+    unused_imports,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::invalid_html_tags,
+    reason = "buffa-build generated code — upstream codegen style; do not police"
+)]
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::Cell,
+};
+
+use buffa::{Message as _, MessageView as _};
+use protovalidate_buffa::Validate as _;
+
+pub mod generated {
+    include!(concat!(env!("OUT_DIR"), "/_include.rs"));
+}
+
+thread_local! {
+    static TRACK_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATION_COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+struct CountingAllocator;
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+// SAFETY: every allocation operation is forwarded to `System` with its
+// arguments unchanged; the side counter is safe thread-local state.
+unsafe impl GlobalAlloc for CountingAllocator {
+    /// # Safety
+    ///
+    /// `layout` must satisfy [`GlobalAlloc::alloc`]'s contract.
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        // SAFETY: `layout` is forwarded unchanged to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    /// # Safety
+    ///
+    /// `layout` must satisfy [`GlobalAlloc::alloc_zeroed`]'s contract.
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        // SAFETY: `layout` is forwarded unchanged to the system allocator.
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    /// # Safety
+    ///
+    /// `ptr` and `layout` must satisfy [`GlobalAlloc::dealloc`]'s contract.
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` and `layout` came from the system allocator.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    /// # Safety
+    ///
+    /// The arguments must satisfy [`GlobalAlloc::realloc`]'s contract.
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        record_allocation();
+        // SAFETY: `ptr` and `layout` came from the system allocator and
+        // `new_size` is forwarded unchanged.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+fn record_allocation() {
+    if TRACK_ALLOCATIONS.try_with(Cell::get).unwrap_or(false) {
+        let _ = ALLOCATION_COUNT.try_with(|count| count.set(count.get() + 1));
+    }
+}
+
+fn allocations_during<T>(f: impl FnOnce() -> T) -> (T, usize) {
+    ALLOCATION_COUNT.with(|count| count.set(0));
+    TRACK_ALLOCATIONS.with(|tracking| tracking.set(true));
+    let result = f();
+    TRACK_ALLOCATIONS.with(|tracking| tracking.set(false));
+    let count = ALLOCATION_COUNT.with(Cell::get);
+    (result, count)
+}
+
+/// # Design
+///
+/// Decoding happens before allocation tracking because Buffa's repeated and
+/// map views intentionally own index vectors. The assertion covers only the
+/// public `Validate::validate` call on already-decoded borrowed views.
+#[test]
+fn valid_borrowed_views_allocate_nothing_during_validation() {
+    use generated::{
+        buf::validate::conformance::cases::{
+            __buffa::view::{FieldMaskConstView, StringConstView},
+            FieldMaskConst, StringConst,
+        },
+        google::protobuf::FieldMask,
+    };
+
+    let mut string_bytes = Vec::new();
+    StringConst {
+        val: "foo".to_owned(),
+        ..Default::default()
+    }
+    .encode(&mut string_bytes);
+    let string_view = StringConstView::decode_view(&string_bytes).expect("decode string view");
+    let (result, allocations) = allocations_during(|| string_view.validate());
+    assert!(result.is_ok());
+    assert_eq!(allocations, 0);
+
+    let mut field_mask_bytes = Vec::new();
+    FieldMaskConst {
+        val: FieldMask {
+            paths: vec!["a".to_owned()],
+            ..Default::default()
+        }
+        .into(),
+        ..Default::default()
+    }
+    .encode(&mut field_mask_bytes);
+    let field_mask_view =
+        FieldMaskConstView::decode_view(&field_mask_bytes).expect("decode field-mask view");
+    let (result, allocations) = allocations_during(|| field_mask_view.validate());
+    assert!(result.is_ok());
+    assert_eq!(allocations, 0);
+}
+
+#[test]
+fn valid_borrowed_map_validation_is_allocation_free() {
+    use generated::buf::validate::conformance::cases::{__buffa::view::MapMinView, MapMin};
+
+    let mut message = MapMin::default();
+    message.val.insert(1, 1.0);
+    message.val.insert(2, 2.0);
+    let mut bytes = Vec::new();
+    message.encode(&mut bytes);
+    let view = MapMinView::decode_view(&bytes).expect("decode map view");
+
+    let (result, allocations) = allocations_during(|| view.validate());
+    assert!(result.is_ok());
+    assert_eq!(allocations, 0);
+}
+
+#[test]
+fn duplicate_borrowed_values_fail_unique_validation() {
+    use generated::buf::validate::conformance::cases::{
+        __buffa::view::RepeatedUniqueView, RepeatedUnique,
+    };
+
+    let mut bytes = Vec::new();
+    RepeatedUnique {
+        val: vec!["duplicate".to_owned(), "duplicate".to_owned()],
+        ..Default::default()
+    }
+    .encode(&mut bytes);
+    let view = RepeatedUniqueView::decode_view(&bytes).expect("decode repeated view");
+
+    assert!(view.validate().is_err());
+}

--- a/crates/protovalidate-buffa-conformance/tests/view_map_semantics.rs
+++ b/crates/protovalidate-buffa-conformance/tests/view_map_semantics.rs
@@ -1,0 +1,65 @@
+#![warn(rust_2018_idioms)]
+#![allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    dead_code,
+    elided_lifetimes_in_paths,
+    non_camel_case_types,
+    unused_imports,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::invalid_html_tags,
+    reason = "buffa-build generated code — upstream codegen style; do not police"
+)]
+
+use buffa::{Message as _, MessageView as _};
+use protovalidate_buffa::Validate as _;
+
+pub mod generated {
+    include!(concat!(env!("OUT_DIR"), "/_include.rs"));
+}
+
+fn fixed32_map_entry(key: u8, value: f32) -> Vec<u8> {
+    let mut entry = vec![0x0a, 0x07, 0x08, key, 0x15];
+    entry.extend_from_slice(&value.to_le_bytes());
+    entry
+}
+
+fn uint_map_entry(key: u8, value: u8) -> [u8; 6] {
+    [0x0a, 0x04, 0x08, key, 0x10, value]
+}
+
+// https://github.com/mathematic-inc/protovalidate-buffa/pull/28
+#[test]
+fn duplicate_keys_do_not_satisfy_min_pairs() {
+    use generated::buf::validate::conformance::cases::{__buffa::view::MapMinView, MapMin};
+
+    let mut bytes = fixed32_map_entry(1, 1.0);
+    bytes.extend(fixed32_map_entry(1, 2.0));
+    let owned = MapMin::decode_from_slice(&bytes).expect("fixture must decode as an owned map");
+    let view = MapMinView::decode_view(&bytes).expect("fixture must decode as a map view");
+
+    assert_eq!(owned.val.len(), 1);
+    assert_eq!(view.val.len(), 2);
+    assert!(owned.validate().is_err());
+    assert!(view.validate().is_err());
+}
+
+// https://github.com/mathematic-inc/protovalidate-buffa/pull/28
+#[test]
+fn duplicate_keys_do_not_inflate_cel_map_size() {
+    use generated::buf::validate::conformance::cases::{
+        __buffa::view::PredefinedMapRuleProto3View, PredefinedMapRuleProto3,
+    };
+
+    let bytes = uint_map_entry(1, 1).repeat(5);
+    let owned = PredefinedMapRuleProto3::decode_from_slice(&bytes)
+        .expect("fixture must decode as an owned map");
+    let view = PredefinedMapRuleProto3View::decode_view(&bytes)
+        .expect("fixture must decode as a map view");
+
+    assert_eq!(owned.val.len(), 1);
+    assert_eq!(view.val.len(), 5);
+    assert!(owned.validate().is_err());
+    assert!(view.validate().is_err());
+}

--- a/crates/protovalidate-buffa/src/__private.rs
+++ b/crates/protovalidate-buffa/src/__private.rs
@@ -1,0 +1,67 @@
+//! Implementation details shared with generated validators.
+
+use std::borrow::Borrow;
+
+/// A zero-allocation, last-write-wins adapter over a protobuf map view.
+///
+/// Buffa's [`buffa::MapView`] retains duplicate wire entries. Validation must
+/// instead observe protobuf map semantics, where only the last value for each
+/// key exists. Buffa's unique iterator provides that behavior without copying
+/// keys or values, at O(n²) worst-case cost.
+#[derive(Debug)]
+pub struct CanonicalMap<'view, 'buffer, K, V> {
+    view: &'view buffa::MapView<'buffer, K, V>,
+}
+
+impl<'view, 'buffer, K, V> CanonicalMap<'view, 'buffer, K, V>
+where
+    K: PartialEq,
+{
+    /// Borrow a Buffa map view with canonical protobuf map semantics.
+    #[must_use]
+    pub const fn from_view(view: &'view buffa::MapView<'buffer, K, V>) -> Self {
+        Self { view }
+    }
+
+    /// Return the number of distinct keys.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.view.len_unique()
+    }
+
+    /// Return whether the canonical map contains no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.view.is_empty()
+    }
+
+    /// Return the last value associated with `key`.
+    #[must_use]
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + ?Sized,
+    {
+        self.view.get(key)
+    }
+
+    /// Return whether `key` is present.
+    #[must_use]
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + ?Sized,
+    {
+        self.view.contains_key(key)
+    }
+
+    /// Iterate over distinct keys at their last wire position.
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.view.iter_unique().map(|(key, _)| key)
+    }
+
+    /// Iterate over distinct key/value pairs at their last wire position.
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.view.iter_unique()
+    }
+}

--- a/crates/protovalidate-buffa/src/lib.rs
+++ b/crates/protovalidate-buffa/src/lib.rs
@@ -12,8 +12,9 @@
 //! There is **no CEL interpreter at runtime**: the paired
 //! `protoc-gen-protovalidate-buffa` plugin transpiles every CEL rule
 //! to native Rust at codegen time. Generated `validate()` methods are
-//! direct field-access checks with zero per-call `Value` / `HashMap`
-//! allocations.
+//! direct field-access checks without per-call dynamic CEL `Value`
+//! materialization. Rules that need scratch state, such as repeated-value
+//! uniqueness, allocate it directly.
 //!
 //! [`ValidationError`] carries three orthogonal signals:
 //!
@@ -30,6 +31,8 @@
 //! covering proto2, proto3, and editions 2023) passes against code
 //! emitted by the paired plugin.
 
+#[doc(hidden)]
+pub mod __private;
 pub mod cel;
 mod error;
 pub mod rules;


### PR DESCRIPTION
## Summary

- emit `Validate` implementations for owned Buffa messages and zero-copy view types from the same generator paths
- preserve borrowed string, bytes, field-mask, oneof, repeated, nested-message, and CEL validation
- apply protobuf last-write-wins semantics to view maps without allocating another map

## Tradeoff

Canonical duplicate-key map iteration uses Buffa allocation-free unique iteration, with O(n²) worst-case behavior.

## Tests

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-features` with Rust 1.88
- `cargo fmt --all -- --check`

Discussion: https://github.com/mathematic-inc/protovalidate-buffa/discussions/33

Proposed by @advait-specter in Discussion #33, with the original draft implementation in #28.