### PR TITLE
ci: harden CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,14 +7,17 @@ on:
   pull_request:
   schedule:
     - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -49,7 +52,9 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
+          build-mode: none
           languages: ${{ matrix.language }}
+          queries: security-extended
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9


### PR DESCRIPTION
## Summary
- run the extended CodeQL security query suite
- declare the supported no-build mode explicitly
- scope security-event writes to the analysis job and allow manual scans

## Validation
- `mise exec -- hk check --all --slow`
- `mise exec -- cargo build --locked --workspace --all-targets --all-features`