### PR TITLE
chore(hk): ignore changelog

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -4,6 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtin
 
 min_hk_version = "1.56.1"
 hide_warnings = List("missing-profiles")
+exclude = List("**/CHANGELOG.md")
 
 local generatedFiles =
   List(


### PR DESCRIPTION
## Summary

- exclude every `CHANGELOG.md` from hk at the configuration root

## Verification

- `mise exec -- hk config get exclude`
- explicit malformed `CHANGELOG.md` invocation was skipped with zero matching files
- `mise exec -- hk check --all --slow`