### PR TITLE
fix(cel): preserve timestamp and duration values across bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -107,9 +107,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "buffa"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
+checksum = "a92f2f5df67a9d5ccfc65237bfc954c56328aee40a04a9b92381ecba370be246"
 dependencies = [
  "bytes",
  "foldhash",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-build"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247d43740a4854a9c1b98a5931d6d67d8f8b41ffeb2a43ca008d460e79b1eb2c"
+checksum = "eee6b6b4a8d23f1f98a043f188f4d9d2ef8bee43191f42e93ac577f3c3b0f334"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-codegen"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2074a9c2f76b2ebe6af40f7bf67b6a19d6ce3663253ef2a55124dc93f38b230e"
+checksum = "bb4bea10ef85ea3d06a20412c67cb612527feb25f33367eab850139441fb5dd9"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-descriptor"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964d735e0b06cb24fa15a68c5aa99549abcc7e0bbeb76298f2fec57912fb79c1"
+checksum = "2b7dd79a6898e70dac8adae959c8ad2cae51ed96397935c91c996280cedcb55e"
 dependencies = [
  "buffa",
  "rustversion",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-types"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7d518783cc611d9f144a71cf7dbc7b5588c5d16ff96ca43e74ac105ea3cb05"
+checksum = "b15b05c8418f1e200e406e5b19df97400dffa833e2450e4392c506896cbc97ac"
 dependencies = [
  "buffa",
  "bytes",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82399e72d100a28a0cac14251a8aba16d124af2a237d8a60ab7997ba7380cc3"
+checksum = "9f93082a93da8fd78394852602ced1e2e7754ed8c29dc813fa80b01a1baf9032"
 dependencies = [
  "antlr4rust",
  "lazy_static",
@@ -227,9 +227,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -292,9 +292,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -348,9 +348,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fluent-uri"
@@ -425,7 +425,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -760,9 +760,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -784,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -809,7 +809,7 @@ dependencies = [
  "proc-macro2",
  "protovalidate-buffa-protos",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -848,7 +848,7 @@ dependencies = [
  "protovalidate-buffa-protos",
  "quote",
  "regex",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -857,7 +857,7 @@ version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -928,7 +928,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1012,7 +1012,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1054,9 +1054,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smoothutf8"
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1125,7 +1125,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1147,7 +1147,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
@@ -13,7 +13,7 @@ use quote::{format_ident, quote};
 use crate::{
     emit::cel_compile::{
         Binding, CelType, CompileOutput, Compiler, FallbackKind, MapTy, MessageFieldEntry,
-        MessageSchema, RustScalar, SchemaFieldKind,
+        MessageSchema, RustScalar, SchemaFieldKind, wkt_value,
     },
     scan::{FieldKind, FieldValidator, MessageValidators},
 };
@@ -402,7 +402,7 @@ pub(crate) fn try_emit_native_field_cel(
     }
     let this_ty = scalar_this_for_with(&f.field_type, Some(schemas))?;
     let access = field_this_access(f, field_ident, &this_ty, shape)?;
-    let mut compiler = Compiler::new();
+    let mut compiler = Compiler::new().with_schemas(schemas);
     compiler.bind(
         "this",
         Binding {
@@ -480,7 +480,10 @@ pub(crate) fn try_emit_native_field_cel(
     let body = quote! {
         let __cel_this = #access;
         #now_prelude
-        #check
+        let _ = (|| -> ::core::option::Option<()> {
+            #check
+            ::core::option::Option::Some(())
+        })();
     };
     Some(match &f.field_type {
         FieldKind::Optional(_) => quote! {
@@ -670,24 +673,7 @@ fn field_this_access(
             CelType::Bool => quote! { self.#field_ident },
             _ => return None,
         }),
-        FieldKind::Message { full_name } if full_name == "google.protobuf.Duration" => {
-            // Caller wraps in `if let Some(__cel_inner) = self.x.as_option()`.
-            Some(quote! {
-                ::protovalidate_buffa::cel::duration_from_secs_nanos(
-                    __cel_inner.seconds,
-                    __cel_inner.nanos,
-                )
-            })
-        }
-        FieldKind::Message { full_name } if full_name == "google.protobuf.Timestamp" => {
-            Some(quote! {
-                ::protovalidate_buffa::cel::timestamp_from_secs_nanos(
-                    __cel_inner.seconds,
-                    __cel_inner.nanos,
-                )
-            })
-        }
-        FieldKind::Message { .. } => None,
+        FieldKind::Message { .. } => wkt_value(cel_ty, &quote! { __cel_inner }),
     }
 }
 
@@ -727,7 +713,7 @@ fn try_emit_native_field_cel_message(
         return None;
     }
     let inner_schema = schemas.get(&inner_full_name)?.clone();
-    let mut compiler = Compiler::new();
+    let mut compiler = Compiler::new().with_schemas(schemas);
     compiler.bind(
         "this",
         Binding {
@@ -785,7 +771,10 @@ fn try_emit_native_field_cel_message(
     };
     let body = quote! {
         #now_prelude
-        #check
+        let _ = (|| -> ::core::option::Option<()> {
+            #check
+            ::core::option::Option::Some(())
+        })();
     };
     // For `Message`-typed fields buffa exposes `MessageField<T>`; for
     // proto2/editions `optional Msg` it's also `MessageField<T>` (via
@@ -842,8 +831,9 @@ pub(crate) fn try_compile_cel_check(
     field_path: &TokenStream,
     rule_path: &TokenStream,
     for_key: bool,
+    schemas: &SchemaIndex,
 ) -> Option<TokenStream> {
-    let mut compiler = Compiler::new();
+    let mut compiler = Compiler::new().with_schemas(schemas);
     compiler.bind(
         "this",
         Binding {
@@ -923,7 +913,10 @@ pub(crate) fn try_compile_cel_check(
     };
     Some(quote! {
         #now_prelude
-        #check
+        let _ = (|| -> ::core::option::Option<()> {
+            #check
+            ::core::option::Option::Some(())
+        })();
     })
 }
 
@@ -948,6 +941,11 @@ pub(crate) fn this_binding_for_kind_with(
     operand: &TokenStream,
     schemas: Option<&SchemaIndex>,
 ) -> Option<(TokenStream, CelType)> {
+    if let Some(ty) = scalar_this_for(kind)
+        && let Some(value) = wkt_value(&ty, operand)
+    {
+        return Some((value, ty));
+    }
     if let FieldKind::Message { full_name } = kind
         && let Some(s) = schemas
         && let Some(schema) = s.get(full_name).cloned()
@@ -1025,11 +1023,10 @@ fn field_to_schema_entry(f: &FieldValidator) -> Option<MessageFieldEntry> {
             let elem = scalar_this_for(inner)?;
             (CelType::List(Box::new(elem)), SchemaFieldKind::Repeated)
         }
-        // Sub-messages and maps: marked as Message kind so `has()` works
-        // but field-selection on them isn't yet supported (the transpiler
-        // falls back when descending into them).
+        // Preserve message presence for `has()`, including WKTs whose CEL
+        // values are timestamps or durations rather than message references.
         FieldKind::Message { full_name } => (
-            CelType::Dyn,
+            scalar_this_for(&f.field_type).unwrap_or(CelType::Dyn),
             SchemaFieldKind::Message {
                 proto_fqn: Some(full_name.clone()),
             },

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
@@ -741,10 +741,10 @@ impl<'a> Compiler<'a> {
             return Ok(Compiled {
                 tokens: quote! {
                     ({
-                        static __TS: ::std::sync::OnceLock<::chrono::DateTime<::chrono::FixedOffset>> =
+                        static __TS: ::std::sync::OnceLock<::protovalidate_buffa::chrono::DateTime<::protovalidate_buffa::chrono::FixedOffset>> =
                             ::std::sync::OnceLock::new();
                         *__TS.get_or_init(|| {
-                            ::chrono::DateTime::parse_from_rfc3339(#s_lit)
+                            ::protovalidate_buffa::chrono::DateTime::parse_from_rfc3339(#s_lit)
                                 .expect("CEL timestamp() literal parse")
                         })
                     })
@@ -2060,7 +2060,7 @@ impl<'a> Compiler<'a> {
             || match &target.ty {
                 CelType::Timestamp => (
                     t.clone(),
-                    quote! { ::chrono::DateTime<::chrono::FixedOffset> },
+                    quote! { ::protovalidate_buffa::chrono::DateTime<::protovalidate_buffa::chrono::FixedOffset> },
                 ),
                 _ => (t.clone(), quote! {}),
             },
@@ -2075,7 +2075,7 @@ impl<'a> Compiler<'a> {
                 };
                 (
                     converted,
-                    quote! { ::chrono::DateTime<::protovalidate_buffa::chrono_tz::Tz> },
+                    quote! { ::protovalidate_buffa::chrono::DateTime<::protovalidate_buffa::chrono_tz::Tz> },
                 )
             },
         );
@@ -2088,37 +2088,37 @@ impl<'a> Compiler<'a> {
             // --- Timestamp ---
             // Date components.
             ("getFullYear", CelType::Timestamp) => quote! {
-                (i64::from(<#ts_ty_path as ::chrono::Datelike>::year(&(#ts_expr))))
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Datelike>::year(&(#ts_expr))))
             },
             ("getMonth", CelType::Timestamp) => quote! {
                 // CEL `getMonth` is 0-based; chrono's `month()` is 1-based.
-                (i64::from(<#ts_ty_path as ::chrono::Datelike>::month(&(#ts_expr))) - 1)
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Datelike>::month(&(#ts_expr))) - 1)
             },
             ("getDate" | "getDayOfMonth", CelType::Timestamp) => quote! {
                 // CEL is 0-based per cel-go; chrono's `day()` is 1-based.
-                (i64::from(<#ts_ty_path as ::chrono::Datelike>::day(&(#ts_expr))) - 1)
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Datelike>::day(&(#ts_expr))) - 1)
             },
             ("getDayOfWeek", CelType::Timestamp) => quote! {
                 // CEL: Sunday = 0.
-                (i64::from(<#ts_ty_path as ::chrono::Datelike>::weekday(&(#ts_expr)).num_days_from_sunday()))
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Datelike>::weekday(&(#ts_expr)).num_days_from_sunday()))
             },
             ("getDayOfYear", CelType::Timestamp) => quote! {
                 // CEL is 0-based; chrono's `ordinal()` is 1-based.
-                (i64::from(<#ts_ty_path as ::chrono::Datelike>::ordinal(&(#ts_expr))) - 1)
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Datelike>::ordinal(&(#ts_expr))) - 1)
             },
             // Time components.
             ("getHours", CelType::Timestamp) => quote! {
-                (i64::from(<#ts_ty_path as ::chrono::Timelike>::hour(&(#ts_expr))))
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Timelike>::hour(&(#ts_expr))))
             },
             ("getMinutes", CelType::Timestamp) => quote! {
-                (i64::from(<#ts_ty_path as ::chrono::Timelike>::minute(&(#ts_expr))))
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Timelike>::minute(&(#ts_expr))))
             },
             ("getSeconds", CelType::Timestamp) => quote! {
-                (i64::from(<#ts_ty_path as ::chrono::Timelike>::second(&(#ts_expr))))
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Timelike>::second(&(#ts_expr))))
             },
             ("getMilliseconds", CelType::Timestamp) => quote! {
                 // chrono `nanosecond()` is sub-second nanos; convert to ms.
-                (i64::from(<#ts_ty_path as ::chrono::Timelike>::nanosecond(&(#ts_expr)) / 1_000_000))
+                (i64::from(<#ts_ty_path as ::protovalidate_buffa::chrono::Timelike>::nanosecond(&(#ts_expr)) / 1_000_000))
             },
             _ => return Err(FallbackReason::new(format!("{name} on {:?}", target.ty))),
         };
@@ -3908,6 +3908,19 @@ fn cast_to_rust_scalar(expr: &TokenStream, cel: &CelType, rust: RustScalar) -> T
     }
 }
 
+/// Convert a protobuf Timestamp or Duration into its native CEL value.
+pub(crate) fn wkt_value(ty: &CelType, operand: &TokenStream) -> Option<TokenStream> {
+    let constructor = match ty {
+        CelType::Timestamp => quote! { timestamp_from_secs_nanos },
+        CelType::Duration => quote! { duration_from_secs_nanos },
+        _ => return None,
+    };
+    Some(quote! {{
+        let __cel_wkt = #operand;
+        ::protovalidate_buffa::cel::#constructor(__cel_wkt.seconds, __cel_wkt.nanos)
+    }})
+}
+
 /// Emit a typed Rust field access for `<operand>.<field>` when the operand
 /// is a known message type.
 fn select_message_field(
@@ -3997,6 +4010,15 @@ fn select_message_field(
             }
         },
         SchemaFieldKind::Message { proto_fqn } => {
+            if let Some(tokens) =
+                wkt_value(&entry.ty, &quote! { #operand.#rust_ident.as_option()? })
+            {
+                return Ok(Compiled {
+                    tokens,
+                    ty: entry.ty.clone(),
+                    constant: None,
+                });
+            }
             // Nested sub-message access (`this.e.a == this.f.a`). The
             // generated code wraps the whole expression in a closure that
             // uses `?` to short-circuit when a sub-message is unset (which

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/repeated.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/repeated.rs
@@ -1745,6 +1745,7 @@ pub fn emit_repeated(
                     &fp_quote,
                     &rp_quote,
                     false,
+                    schemas,
                 )
             });
             if let Some(check) = native {
@@ -1826,7 +1827,7 @@ pub fn emit_repeated(
                     Some(schemas),
                 )?;
                 crate::emit::cel::try_compile_cel_check(
-                    expr, id, msg, this_expr, this_ty, None, &fp_quote, &rp_quote, false,
+                    expr, id, msg, this_expr, this_ty, None, &fp_quote, &rp_quote, false, schemas,
                 )
             });
             if let Some(check) = native {
@@ -2130,7 +2131,7 @@ pub fn emit_map(
                 let (this_expr, this_ty) =
                     crate::emit::cel::this_binding_for_kind_with(target_kind, &a, Some(schemas))?;
                 crate::emit::cel::try_compile_cel_check(
-                    expr, id, msg, this_expr, this_ty, None, &fp_quote, &rp_quote, for_key,
+                    expr, id, msg, this_expr, this_ty, None, &fp_quote, &rp_quote, for_key, schemas,
                 )
             });
             if let Some(check) = native {

--- a/crates/protovalidate-buffa-conformance/build.rs
+++ b/crates/protovalidate-buffa-conformance/build.rs
@@ -206,6 +206,7 @@ fn enabled_case_files() -> Vec<String> {
         "wkt_timestamp.proto",
         "wkt_field_mask.proto",
         "wkt_nested.proto",
+        "cel_message_wkt.proto",
         "ignore_proto2.proto",
         "ignore_empty_proto2.proto",
         "required_field_proto2.proto",

--- a/crates/protovalidate-buffa-conformance/proto/buf/validate/conformance/cases/cel_message_wkt.proto
+++ b/crates/protovalidate-buffa-conformance/proto/buf/validate/conformance/cases/cel_message_wkt.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package buf.validate.conformance.cases;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+// Regression for https://github.com/mathematic-inc/protovalidate-buffa/discussions/44.
+message CelTimestampRange {
+  option (buf.validate.message).cel = {
+    id: "timestamp_range.ordered"
+    expression: "!has(this.start) || !has(this.end) || this.start < this.end"
+  };
+  google.protobuf.Timestamp start = 1;
+  google.protobuf.Timestamp end = 2;
+}
+
+message CelDurationRange {
+  option (buf.validate.message).cel = {
+    id: "duration_range.ordered"
+    expression: "!has(this.start) || !has(this.end) || this.start < this.end"
+  };
+  google.protobuf.Duration start = 1;
+  google.protobuf.Duration end = 2;
+}
+
+message CelWktElements {
+  repeated google.protobuf.Timestamp timestamps = 1 [(buf.validate.field).repeated.items.cel = {
+    id: "timestamp.after_epoch"
+    expression: "this > timestamp('1970-01-01T00:00:00Z')"
+  }];
+  map<string, google.protobuf.Duration> durations = 2 [(buf.validate.field).map.values.cel = {
+    id: "duration.positive"
+    expression: "this > duration('0s')"
+  }];
+}
+
+message CelTimestampFields {
+  google.protobuf.Timestamp start = 1;
+  google.protobuf.Timestamp end = 2;
+}
+
+message CelTimestampEnvelope {
+  CelTimestampFields range = 1;
+}
+
+message CelNestedTimestampRange {
+  CelTimestampEnvelope envelope = 1 [(buf.validate.field).cel = {
+    id: "nested_timestamp_range.ordered"
+    expression: "!has(this.range) || !has(this.range.start) || !has(this.range.end) || this.range.start < this.range.end"
+  }];
+}

--- a/crates/protovalidate-buffa-conformance/tests/cel_message_wkt.rs
+++ b/crates/protovalidate-buffa-conformance/tests/cel_message_wkt.rs
@@ -1,0 +1,186 @@
+#![warn(rust_2018_idioms)]
+
+use buffa::{Message as _, MessageView as _};
+use protovalidate_buffa::Validate as _;
+
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    dead_code,
+    elided_lifetimes_in_paths,
+    non_camel_case_types,
+    unused_imports,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::invalid_html_tags,
+    reason = "buffa-build generated code"
+)]
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/_include.rs"));
+}
+
+macro_rules! range_test {
+    ($name:ident, $owned:ident, $view:ident, $wkt:ident, $rule:literal) => {
+        // https://github.com/mathematic-inc/protovalidate-buffa/discussions/44
+        #[test]
+        fn $name() {
+            use generated::buf::validate::conformance::cases::{__buffa::view::$view, $owned};
+
+            for (start, end, valid) in [
+                (None, None, true),
+                (Some((0, 0)), None, true),
+                (None, Some((0, 0)), true),
+                (Some((0, 0)), Some((0, 0)), false),
+                (Some((0, 0)), Some((0, 1)), true),
+                (Some((0, 1)), Some((0, 0)), false),
+                (Some((-1, 0)), Some((0, 0)), true),
+                (Some((1, 0)), Some((0, 0)), false),
+            ] {
+                let field = |value: Option<(i64, i32)>| {
+                    value
+                        .map(|(seconds, nanos)| generated::google::protobuf::$wkt {
+                            seconds,
+                            nanos,
+                            ..Default::default()
+                        })
+                        .into()
+                };
+                let owned = $owned {
+                    start: field(start),
+                    end: field(end),
+                    ..Default::default()
+                };
+                let bytes = owned.encode_to_vec();
+                let view = $view::decode_view(&bytes).expect("range must decode");
+                for result in [owned.validate(), view.validate()] {
+                    assert_eq!(result.is_ok(), valid, "{start:?} < {end:?}: {result:?}");
+                    if let Err(error) = result {
+                        assert!(error.compile_error.is_none(), "{error:?}");
+                        assert!(error.runtime_error.is_none(), "{error:?}");
+                        assert_eq!(error.violations.len(), 1);
+                        assert_eq!(error.violations[0].rule_id, $rule);
+                    }
+                }
+            }
+        }
+    };
+}
+
+range_test!(
+    timestamp_ordering_preserves_presence,
+    CelTimestampRange,
+    CelTimestampRangeView,
+    Timestamp,
+    "timestamp_range.ordered"
+);
+range_test!(
+    duration_ordering_preserves_presence,
+    CelDurationRange,
+    CelDurationRangeView,
+    Duration,
+    "duration_range.ordered"
+);
+
+// https://github.com/mathematic-inc/protovalidate-buffa/discussions/44
+#[test]
+fn wkt_item_and_map_value_rules_use_cel_values() {
+    use generated::buf::validate::conformance::cases::{
+        __buffa::view::CelWktElementsView, CelWktElements,
+    };
+    use generated::google::protobuf::{Duration, Timestamp};
+
+    for (seconds, nanos, valid) in [(0, 1, true), (1, 0, true), (0, 0, false), (-1, 0, false)] {
+        let owned = CelWktElements {
+            timestamps: vec![Timestamp {
+                seconds,
+                nanos,
+                ..Default::default()
+            }],
+            durations: [(
+                "value".to_string(),
+                Duration {
+                    seconds,
+                    nanos,
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        let bytes = owned.encode_to_vec();
+        let view = CelWktElementsView::decode_view(&bytes).expect("elements must decode");
+        for result in [owned.validate(), view.validate()] {
+            assert_eq!(result.is_ok(), valid, "{seconds}s {nanos}ns: {result:?}");
+            if let Err(error) = result {
+                assert!(error.compile_error.is_none(), "{error:?}");
+                assert!(error.runtime_error.is_none(), "{error:?}");
+                let ids: Vec<_> = error
+                    .violations
+                    .iter()
+                    .map(|v| v.rule_id.as_ref())
+                    .collect();
+                assert_eq!(ids, ["timestamp.after_epoch", "duration.positive"]);
+            }
+        }
+    }
+}
+
+// https://github.com/mathematic-inc/protovalidate-buffa/discussions/44
+#[test]
+fn nested_field_rules_preserve_presence() {
+    use generated::buf::validate::conformance::cases::{
+        __buffa::view::CelNestedTimestampRangeView, CelNestedTimestampRange, CelTimestampEnvelope,
+        CelTimestampFields,
+    };
+    use generated::google::protobuf::Timestamp;
+
+    for (range, valid) in [
+        (None, true),
+        (Some(CelTimestampFields::default()), true),
+        (
+            Some(CelTimestampFields {
+                start: Timestamp::default().into(),
+                end: Timestamp {
+                    nanos: 1,
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
+            }),
+            true,
+        ),
+        (
+            Some(CelTimestampFields {
+                start: Timestamp::default().into(),
+                end: Timestamp::default().into(),
+                ..Default::default()
+            }),
+            false,
+        ),
+    ] {
+        let owned = CelNestedTimestampRange {
+            envelope: CelTimestampEnvelope {
+                range: range.into(),
+                ..Default::default()
+            }
+            .into(),
+            ..Default::default()
+        };
+        let bytes = owned.encode_to_vec();
+        let view =
+            CelNestedTimestampRangeView::decode_view(&bytes).expect("nested range must decode");
+        for result in [owned.validate(), view.validate()] {
+            assert_eq!(result.is_ok(), valid, "{result:?}");
+            if let Err(error) = result {
+                assert!(error.compile_error.is_none(), "{error:?}");
+                assert!(error.runtime_error.is_none(), "{error:?}");
+                assert_eq!(error.violations.len(), 1);
+                assert_eq!(
+                    error.violations[0].rule_id,
+                    "nested_timestamp_range.ordered"
+                );
+            }
+        }
+    }
+}

--- a/crates/protovalidate-buffa-conformance/tests/cel_message_wkt.rs
+++ b/crates/protovalidate-buffa-conformance/tests/cel_message_wkt.rs
@@ -96,15 +96,14 @@ fn wkt_item_and_map_value_rules_use_cel_values() {
                 nanos,
                 ..Default::default()
             }],
-            durations: [(
+            durations: std::iter::once((
                 "value".to_string(),
                 Duration {
                     seconds,
                     nanos,
                     ..Default::default()
                 },
-            )]
-            .into_iter()
+            ))
             .collect(),
             ..Default::default()
         };

--- a/crates/protovalidate-buffa/src/lib.rs
+++ b/crates/protovalidate-buffa/src/lib.rs
@@ -46,6 +46,8 @@ mod connect;
 // `::buffa::` path directly; downstream crates already depend on buffa for
 // their message types.
 pub use buffa;
+/// Date/time types and traits used by generated CEL timestamp expressions.
+pub use chrono;
 /// IANA timezone database, re-exported so generated code can reference
 /// `::protovalidate_buffa::chrono_tz::Tz` when a CEL rule uses the
 /// timezone-argument form of a timestamp accessor


### PR DESCRIPTION
Fixes the Timestamp comparison failure reported in [discussion #44](https://github.com/mathematic-inc/protovalidate-buffa/discussions/44), reported and diagnosed by @LuKev. Timestamp and Duration fields now use CEL temporal values while `has()` continues to check protobuf presence.

The same conversion now handles repeated-item and map-value rules. Field and element rules receive the schema index and skip unset nested messages consistently. Generated timestamp literals and accessors use the runtime's `chrono` re-export, so consumers do not need a direct `chrono` dependency. Regenerate validators with the new generator and update the runtime together.

Validation: 182 workspace tests pass, including four regression tests for owned messages and borrowed views. The original and related regression tests failed before their respective fixes. Workspace build, Clippy with all features and warnings denied, formatting, and protobuf lint pass. The lockfile is refreshed as required by the repository freshness check; CI also verifies Rust 1.88 compatibility.
