### PR TITLE
fix(cel): read protobuf defaults for unset message fields

### DIFF
--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
@@ -480,10 +480,7 @@ pub(crate) fn try_emit_native_field_cel(
     let body = quote! {
         let __cel_this = #access;
         #now_prelude
-        let _ = (|| -> ::core::option::Option<()> {
-            #check
-            ::core::option::Option::Some(())
-        })();
+        #check
     };
     Some(match &f.field_type {
         FieldKind::Optional(_) => quote! {
@@ -771,10 +768,7 @@ fn try_emit_native_field_cel_message(
     };
     let body = quote! {
         #now_prelude
-        let _ = (|| -> ::core::option::Option<()> {
-            #check
-            ::core::option::Option::Some(())
-        })();
+        #check
     };
     // For `Message`-typed fields buffa exposes `MessageField<T>`; for
     // proto2/editions `optional Msg` it's also `MessageField<T>` (via
@@ -913,10 +907,7 @@ pub(crate) fn try_compile_cel_check(
     };
     Some(quote! {
         #now_prelude
-        let _ = (|| -> ::core::option::Option<()> {
-            #check
-            ::core::option::Option::Some(())
-        })();
+        #check
     })
 }
 
@@ -1073,15 +1064,9 @@ fn try_emit_native_message_cel(
     };
     let id_lit = &rule.id;
     let msg_lit = &rule.message;
-    // Wrap the body in a closure that returns `Option<T>` so nested
-    // sub-message accesses (`this.e.a == this.f.a`) can short-circuit via
-    // `?` when a sub-message is unset. Mirrors protovalidate's
-    // `NoSuchKey => skip` semantics for `(message).cel` rules.
     let check = match ty {
         CelType::Bool => quote! {
-            let __cel_result: ::core::option::Option<bool> =
-                (|| -> ::core::option::Option<bool> { ::core::option::Option::Some(#tokens) })();
-            if ::core::matches!(__cel_result, ::core::option::Option::Some(false)) {
+            if !(#tokens) {
                 violations.push(::protovalidate_buffa::Violation {
                     field: ::protovalidate_buffa::FieldPath::default(),
                     rule: ::protovalidate_buffa::FieldPath::default(),
@@ -1092,33 +1077,23 @@ fn try_emit_native_message_cel(
             }
         },
         CelType::Str { owned: true } => quote! {
-            let __cel_result: ::core::option::Option<::std::string::String> =
-                (|| -> ::core::option::Option<::std::string::String> {
-                    ::core::option::Option::Some((#tokens))
-                })();
-            if let ::core::option::Option::Some(__cel_s) = __cel_result {
-                if !__cel_s.is_empty() {
-                    let __msg: ::std::borrow::Cow<'static, str> = if (#msg_lit as &str).is_empty() {
-                        ::std::borrow::Cow::Owned(__cel_s)
-                    } else {
-                        ::std::borrow::Cow::Borrowed(#msg_lit)
-                    };
-                    violations.push(::protovalidate_buffa::Violation {
-                        field: ::protovalidate_buffa::FieldPath::default(),
-                        rule: ::protovalidate_buffa::FieldPath::default(),
-                        rule_id: ::std::borrow::Cow::Borrowed(#id_lit),
-                        message: __msg,
-                        for_key: false,
-                    });
-                }
+            let __cel_s: ::std::string::String = (#tokens);
+            if !__cel_s.is_empty() {
+                let __msg: ::std::borrow::Cow<'static, str> = if (#msg_lit as &str).is_empty() {
+                    ::std::borrow::Cow::Owned(__cel_s)
+                } else {
+                    ::std::borrow::Cow::Borrowed(#msg_lit)
+                };
+                violations.push(::protovalidate_buffa::Violation {
+                    field: ::protovalidate_buffa::FieldPath::default(),
+                    rule: ::protovalidate_buffa::FieldPath::default(),
+                    rule_id: ::std::borrow::Cow::Borrowed(#id_lit),
+                    message: __msg,
+                    for_key: false,
+                });
             }
         },
         CelType::Str { owned: false } => quote! {
-            // Borrowed-string result captures `self` so it can't escape a
-            // closure without lifetime gymnastics. Inline the check
-            // directly — borrowed-string results never reference sub-
-            // messages that might be unset (only literals + receiver
-            // access), so no `?` short-circuit is needed.
             {
                 let __cel_result: &str = (#tokens);
                 if !__cel_result.is_empty() {

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
@@ -4010,28 +4010,22 @@ fn select_message_field(
             }
         },
         SchemaFieldKind::Message { proto_fqn } => {
-            if let Some(tokens) =
-                wkt_value(&entry.ty, &quote! { #operand.#rust_ident.as_option()? })
-            {
+            if let Some(tokens) = wkt_value(&entry.ty, &quote! { &*#operand.#rust_ident }) {
                 return Ok(Compiled {
                     tokens,
                     ty: entry.ty.clone(),
                     constant: None,
                 });
             }
-            // Nested sub-message access (`this.e.a == this.f.a`). The
-            // generated code wraps the whole expression in a closure that
-            // uses `?` to short-circuit when a sub-message is unset (which
-            // matches protovalidate's NoSuchKey-as-skip semantics for
-            // `(message).cel`). Emit a `MessageField::as_option()?` so the
-            // closure short-circuits.
+            // CEL reads protobuf defaults for unset sub-messages. Buffa's
+            // Deref provides the default instance without changing presence.
             let Some(fqn) = proto_fqn else {
                 return Err(FallbackReason::new(format!(
                     "message field {field} has no proto FQN"
                 )));
             };
             return Ok(Compiled {
-                tokens: quote! { (#operand.#rust_ident.as_option()?) },
+                tokens: quote! { (&*#operand.#rust_ident) },
                 ty: CelType::MessageRef(fqn.clone()),
                 constant: None,
             });
@@ -4924,11 +4918,14 @@ mod tests {
         let out = c.compile("this.b.c.x > 0").expect("compile");
         assert_eq!(out.ty, CelType::Bool);
         let r = rendered(&out.tokens);
-        // Both intermediate hops emit as_option()? — the closure
-        // short-circuits if any link is unset.
+        assert_eq!(
+            r.matches("& *").count(),
+            2,
+            "expected default-value reads: {r}"
+        );
         assert!(
-            r.matches("as_option").count() >= 2,
-            "expected ≥2 as_option(): {r}"
+            !r.contains("as_option"),
+            "field access must not skip unset messages: {r}"
         );
     }
 
@@ -6082,15 +6079,11 @@ mod tests {
         let out = c.compile("this.e.a > 0").expect("compile");
         assert_eq!(out.ty, CelType::Bool);
         let s = out.tokens.to_string();
-        // The `?` short-circuit on the sub-message lookup must be emitted
-        // so the validate body skips the rule when `e` is unset.
+        assert!(s.contains("& *"), "expected default-value read: {s}");
+        assert!(s.contains(". a"), "expected nested .a access: {s}");
         assert!(
-            s.contains("as_option ()"),
-            "expected as_option() on sub-message: {s}"
-        );
-        assert!(
-            s.contains("? )") || s.contains("? . a") || s.contains(". a"),
-            "expected nested .a access: {s}"
+            !s.contains("as_option"),
+            "field access must not skip unset messages: {s}"
         );
     }
 }

--- a/crates/protovalidate-buffa-conformance/proto/buf/validate/conformance/cases/cel_message_wkt.proto
+++ b/crates/protovalidate-buffa-conformance/proto/buf/validate/conformance/cases/cel_message_wkt.proto
@@ -51,3 +51,29 @@ message CelNestedTimestampRange {
     expression: "!has(this.range) || !has(this.range.start) || !has(this.range.end) || this.range.start < this.range.end"
   }];
 }
+
+// Unguarded access reads protobuf defaults, even when has() is false.
+message CelTimestampDefaults {
+  option (buf.validate.message).cel = {
+    id: "timestamp_defaults.ordered"
+    expression: "this.start < this.end"
+  };
+  google.protobuf.Timestamp start = 1;
+  google.protobuf.Timestamp end = 2;
+}
+
+message CelDurationDefaults {
+  option (buf.validate.message).cel = {
+    id: "duration_defaults.ordered"
+    expression: "this.start < this.end"
+  };
+  google.protobuf.Duration start = 1;
+  google.protobuf.Duration end = 2;
+}
+
+message CelNestedTimestampDefaults {
+  CelTimestampEnvelope envelope = 1 [(buf.validate.field).cel = {
+    id: "nested_timestamp_defaults.ordered"
+    expression: "this.range.start < this.range.end"
+  }];
+}

--- a/crates/protovalidate-buffa-conformance/tests/cel_message_wkt.rs
+++ b/crates/protovalidate-buffa-conformance/tests/cel_message_wkt.rs
@@ -20,16 +20,19 @@ mod generated {
 }
 
 macro_rules! range_test {
-    ($name:ident, $owned:ident, $view:ident, $wkt:ident, $rule:literal) => {
+    ($name:ident, $owned:ident, $view:ident, $wkt:ident, $rule:literal, $guarded:literal) => {
         // https://github.com/mathematic-inc/protovalidate-buffa/discussions/44
         #[test]
         fn $name() {
             use generated::buf::validate::conformance::cases::{__buffa::view::$view, $owned};
 
             for (start, end, valid) in [
-                (None, None, true),
-                (Some((0, 0)), None, true),
-                (None, Some((0, 0)), true),
+                (None, None, $guarded),
+                (Some((0, 0)), None, $guarded),
+                (None, Some((0, 0)), $guarded),
+                (None, Some((0, 1)), true),
+                (Some((-1, 0)), None, true),
+                (None, Some((-1, 0)), $guarded),
                 (Some((0, 0)), Some((0, 0)), false),
                 (Some((0, 0)), Some((0, 1)), true),
                 (Some((0, 1)), Some((0, 0)), false),
@@ -71,14 +74,16 @@ range_test!(
     CelTimestampRange,
     CelTimestampRangeView,
     Timestamp,
-    "timestamp_range.ordered"
+    "timestamp_range.ordered",
+    true
 );
 range_test!(
     duration_ordering_preserves_presence,
     CelDurationRange,
     CelDurationRangeView,
     Duration,
-    "duration_range.ordered"
+    "duration_range.ordered",
+    true
 );
 
 // https://github.com/mathematic-inc/protovalidate-buffa/discussions/44
@@ -178,6 +183,77 @@ fn nested_field_rules_preserve_presence() {
                 assert_eq!(
                     error.violations[0].rule_id,
                     "nested_timestamp_range.ordered"
+                );
+            }
+        }
+    }
+}
+
+// Expected values verified against protovalidate-go at
+// 573e8070aa030baf4d4f574293364b998a133a52 using these descriptors.
+range_test!(
+    unset_timestamps_read_as_epoch,
+    CelTimestampDefaults,
+    CelTimestampDefaultsView,
+    Timestamp,
+    "timestamp_defaults.ordered",
+    false
+);
+range_test!(
+    unset_durations_read_as_zero,
+    CelDurationDefaults,
+    CelDurationDefaultsView,
+    Duration,
+    "duration_defaults.ordered",
+    false
+);
+
+// https://github.com/mathematic-inc/protovalidate-buffa/discussions/44
+// Upstream skips rules on an absent envelope; reads inside a present envelope
+// use defaults for absent nested messages and temporal fields.
+#[test]
+fn nested_reads_use_defaults_but_absent_field_rules_are_skipped() {
+    use generated::buf::validate::conformance::cases::{
+        __buffa::view::CelNestedTimestampDefaultsView, CelNestedTimestampDefaults,
+        CelTimestampEnvelope, CelTimestampFields,
+    };
+    use generated::google::protobuf::Timestamp;
+
+    for (envelope, valid) in [
+        (None, true),
+        (Some(CelTimestampEnvelope::default()), false),
+        (
+            Some(CelTimestampEnvelope {
+                range: CelTimestampFields {
+                    end: Timestamp {
+                        nanos: 1,
+                        ..Default::default()
+                    }
+                    .into(),
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
+            }),
+            true,
+        ),
+    ] {
+        let owned = CelNestedTimestampDefaults {
+            envelope: envelope.into(),
+            ..Default::default()
+        };
+        let bytes = owned.encode_to_vec();
+        let view = CelNestedTimestampDefaultsView::decode_view(&bytes)
+            .expect("nested defaults must decode");
+        for result in [owned.validate(), view.validate()] {
+            assert_eq!(result.is_ok(), valid, "{result:?}");
+            if let Err(error) = result {
+                assert!(error.compile_error.is_none(), "{error:?}");
+                assert!(error.runtime_error.is_none(), "{error:?}");
+                assert_eq!(error.violations.len(), 1);
+                assert_eq!(
+                    error.violations[0].rule_id,
+                    "nested_timestamp_defaults.ordered"
                 );
             }
         }


### PR DESCRIPTION
CEL field reads must match protobuf defaults: an unset Timestamp reads as Unix epoch, an unset Duration reads as zero, and an unset nested message exposes its default instance. Presence remains false for `has()`. The previous `as_option()?` emission skipped entire rules, incorrectly accepting unguarded comparisons.

Use Buffa's default-instance dereference for message field selection and remove the skip-on-unset closures. Keep the existing presence guard for rules attached to an absent field, matching upstream Protovalidate.

Follow-up to [#45](https://github.com/mathematic-inc/protovalidate-buffa/pull/45) and [discussion #44](https://github.com/mathematic-inc/protovalidate-buffa/discussions/44), originally reported by @LuKev. The release remains paused until this correction is included.

Validated expected semantics directly against protovalidate-go commit `573e8070aa030baf4d4f574293364b998a133a52` using the same protobuf descriptors. Three new regressions fail before the correction and pass afterward, covering owned messages and borrowed views. All 185 workspace tests pass.

The workspace build and Clippy with all features and warnings denied pass. The official protovalidate-conformance v1.2.2 harness reports `PASS (failed: 0, skipped: 0, passed: 2872, total: 2872)`.
