### PR TITLE
fix(ci): secure dependencies and protect release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: "34.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          install_args: protoc
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
@@ -55,10 +54,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: "34.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          install_args: protoc
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.88.0"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
+        uses: anthropics/claude-code-action@e8c2d7c16c018cf1e694711c1c07a5f5db2b5eb1 # v1.0.208
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
+        uses: anthropics/claude-code-action@e8c2d7c16c018cf1e694711c1c07a5f5db2b5eb1 # v1.0.208
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,10 +34,9 @@ jobs:
 
       - name: Install protoc
         if: matrix.language == 'rust'
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: "34.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          install_args: protoc
 
       - name: Install Rust toolchain
         if: matrix.language == 'rust'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,60 +4,33 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.2.0)"
+        description: Existing release tag
         required: true
         type: string
 
 concurrency:
-  group: release-notes-${{ github.event.inputs.tag }}
-  cancel-in-progress: true
+  group: release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   enhance:
-    name: Enhance release notes with Claude
+    name: Update release notes
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    environment: release
     permissions:
       contents: write
-      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Write release notes with Claude
-        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write"
-          prompt: |
-            Write an exciting, polished GitHub release body for protovalidate-buffa ${{ inputs.tag }} and save it to `release-notes.md`.
-
-            protovalidate-buffa is a static-codegen implementation of Buf's `protovalidate` for the [buffa](https://github.com/anthropics/buffa) Rust protobuf runtime. It passes **2872 / 2872 (100%)** of the upstream `protovalidate-conformance` suite across proto2, proto3, and editions 2023.
-
-            It ships four published crates (plus a private in-repo conformance harness that isn't part of the release surface):
-            - `protovalidate-buffa` — runtime: `Validate` trait, structured `ValidationError` (with typed `violations` / `compile_error` / `runtime_error` slots), `Violation` / `FieldPath`, CEL integration via `cel-interpreter`, Connect error adapter.
-            - `protovalidate-buffa-macros` — `#[connect_impl]` proc macro that inserts `req.validate()?` across every handler in a Connect service `impl`.
-            - `protoc-gen-protovalidate-buffa` — the codegen plugin (`buf generate`). Walks `(buf.validate.*)` extensions end-to-end including predefined rules on `buf.validate.*Rules`.
-            - `protovalidate-buffa-protos` — compiled Rust types for `buf/validate/validate.proto`.
-
-            Steps:
-            1. Run `git describe --tags --abbrev=0 HEAD^` to get the previous tag, then `git log <previous-tag>..HEAD --oneline` for commits in this release.
-            2. Read `README.md`, `crates/protovalidate-buffa/src/lib.rs`, and skim the plugin's `crates/protoc-gen-protovalidate-buffa/src/` tree to ground changes in the actual API surface.
-            3. Write the release body to `release-notes.md`. It should:
-               - Open with an enthusiastic one-paragraph summary of what's new or why this release is exciting.
-               - Have clearly labelled sections (e.g. **✨ New Features**, **🐛 Bug Fixes**, **⚡ Improvements**) — only include sections that actually have content.
-               - For any significant new feature, include a short Rust or proto snippet showing it in action.
-               - Call out the current conformance status (2872 / 2872) when relevant to the release.
-               - Match on the typed `ValidationError.compile_error` / `runtime_error` fields in any error-handling examples — never on `rule_id` prefixes.
-               - End with an installation snippet: for library consumers, `protovalidate-buffa = "${{ inputs.tag }}"` in `Cargo.toml` (stripping the leading `v`); for the plugin, `cargo install --git https://github.com/mathematic-inc/protovalidate-buffa --tag ${{ inputs.tag }} protoc-gen-protovalidate-buffa`.
-               - Be written in an upbeat, developer-friendly tone — celebrate the work!
-            Do NOT publish it yourself — a subsequent step will do that.
-
-      - name: Publish release notes
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ inputs.tag }}
-          body_path: release-notes.md
+      - name: Generate notes for the existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null
+          gh api --method POST "repos/$GH_REPO/releases/generate-notes" \
+            -f tag_name="$RELEASE_TAG" --jq .body > release-notes.md
+          gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --notes-file release-notes.md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,11 +10,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,10 @@ jobs:
           persist-credentials: false
 
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: "34.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          install_args: protoc
+          cache: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -161,10 +161,10 @@ jobs:
           persist-credentials: false
 
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: "34.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          install_args: protoc
+          cache: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable

--- a/hk.pkl
+++ b/hk.pkl
@@ -183,8 +183,7 @@ local checks = new Mapping<String, Step> {
   // Rust.
   ["cargo-lockfile"] = new Step {
     glob = List("Cargo.toml", "Cargo.lock", "**/Cargo.toml")
-    check =
-      "worktree=$(mktemp -d) && trap 'rm -rf \"$worktree\"' EXIT && git ls-files -z | tar --null -T - -cf - | tar -xf - -C \"$worktree\" && cargo generate-lockfile --manifest-path \"$worktree/Cargo.toml\" && diff -u Cargo.lock \"$worktree/Cargo.lock\""
+    check = "cargo metadata --locked --format-version 1 --all-features > /dev/null"
     profiles = slow
   }
   ["cargo-fmt"] = (Builtins.cargo_fmt) {


### PR DESCRIPTION
Replace the deprecated Node 20 protoc action with the repository's pinned mise tool, disabling caches in release jobs. Validate the committed Cargo lockfile without regeneration, update Claude actions, and protect release automation with the release environment. Generate release notes through GitHub's native API.

Validation: local exhaustive hk checks and workspace tests passed. Test, claude-review, Analyze (actions), Check, Analyze (rust), Rust 1.88.0, CodeQL all passed in GitHub at commit d9fb4e622a3c4fa152609e390f362c0765421d84.
