### PR TITLE
fix(cel): preserve oneof presence semantics

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
   "crates/protovalidate-buffa": "0.7.1",
   "crates/protovalidate-buffa-protos": "0.7.0",
   "crates/protovalidate-buffa-macros": "0.4.0",
-  "crates/protoc-gen-protovalidate-buffa": "0.7.2",
+  "crates/protoc-gen-protovalidate-buffa": "0.7.3",
   "crates/protovalidate-buffa-conformance": "0.0.15"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "protoc-gen-protovalidate-buffa"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "buffa",

--- a/crates/protoc-gen-protovalidate-buffa/CHANGELOG.md
+++ b/crates/protoc-gen-protovalidate-buffa/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.3](https://github.com/mathematic-inc/protovalidate-buffa/compare/protoc-gen-protovalidate-buffa-v0.7.2...protoc-gen-protovalidate-buffa-v0.7.3) (2026-09-06)
+
+
+### Bug Fixes
+
+* **cel:** Preserve oneof presence semantics in `has()` expressions for owned messages and borrowed views, including nested and repeated messages.
+* **cel:** Resolve repeated and recursive message schemas lazily so collection expressions can access their elements.
+* **oneof:** Count selected default values correctly in message-level oneof rules and avoid direct field guards for oneof members.
+
 ## [0.7.2](https://github.com/mathematic-inc/protovalidate-buffa/compare/protoc-gen-protovalidate-buffa-v0.7.1...protoc-gen-protovalidate-buffa-v0.7.2) (2026-09-04)
 
 

--- a/crates/protoc-gen-protovalidate-buffa/Cargo.toml
+++ b/crates/protoc-gen-protovalidate-buffa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protoc-gen-protovalidate-buffa"
-version = "0.7.2"
+version = "0.7.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
@@ -32,7 +32,18 @@ pub(crate) fn emit_message_level(
 ) -> (Vec<TokenStream>, Vec<TokenStream>) {
     let statics = Vec::new();
     let mut calls = Vec::new();
-    let msg_schema = build_message_schema(msg);
+    let mut msg_schema = build_message_schema(msg);
+    let mut shaped_schemas = schemas.clone();
+    if matches!(shape, crate::emit::Shape::View) {
+        for schema in std::iter::once(&mut msg_schema).chain(shaped_schemas.values_mut()) {
+            for entry in &mut schema.fields {
+                if let SchemaFieldKind::Oneof { view, .. } = &mut entry.kind {
+                    *view = true;
+                }
+            }
+        }
+    }
+    let schemas = &shaped_schemas;
     for rule in &msg.message_cel {
         if let Some(native) = try_emit_native_message_cel(rule, &msg_schema, schemas) {
             calls.push(native);
@@ -548,11 +559,12 @@ fn scalar_this_for_with(kind: &FieldKind, schemas: Option<&SchemaIndex>) -> Opti
             return Some(CelType::Timestamp);
         }
         FieldKind::Message { full_name } => {
-            // For a Message-typed element we need the schema of that
-            // message to compile nested selects. Without a schema, fall
-            // back.
-            let schema = schemas?.get(full_name)?.clone();
-            return Some(CelType::Message(Box::new(schema)));
+            // Keep message references when building the schema index. Resolving
+            // them lazily supports repeated and cyclic message declarations.
+            return Some(schemas.and_then(|index| index.get(full_name)).map_or_else(
+                || CelType::MessageRef(full_name.clone()),
+                |schema| CelType::Message(Box::new(schema.clone())),
+            ));
         }
         FieldKind::Map { key, value } => {
             let key_cel = scalar_this_for_with(key, schemas)?;
@@ -979,7 +991,24 @@ fn build_message_schema(msg: &MessageValidators) -> MessageSchema {
         .field_rules
         .iter()
         .filter(|f| f.field_number != -1)
-        .filter_map(field_to_schema_entry)
+        .filter_map(|field| {
+            let mut entry = field_to_schema_entry(field)?;
+            if let Some(oneof) = msg.oneof_rules.iter().find(|oneof| {
+                oneof
+                    .fields
+                    .iter()
+                    .any(|candidate| candidate.field_number == field.field_number)
+            }) {
+                entry.kind = SchemaFieldKind::Oneof {
+                    accessor: oneof.name.clone(),
+                    module: super::oneof::to_snake_case(&oneof.parent_msg_name),
+                    enumeration: super::oneof::to_pascal_case(&oneof.name),
+                    variant: super::oneof::to_pascal_case(&field.field_name),
+                    view: false,
+                };
+            }
+            Some(entry)
+        })
         .collect();
     MessageSchema { fields }
 }
@@ -1271,6 +1300,59 @@ fn rule_path_for_field_cel(is_cel_expression: bool, idx_lit: u64) -> TokenStream
                     subscript: Some(::protovalidate_buffa::Subscript::Index(#idx_lit)),
                 }],
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_messages_remain_available_to_message_cel() {
+        let kind = FieldKind::Repeated(Box::new(FieldKind::Message {
+            full_name: "test.Child".to_owned(),
+        }));
+        let ty = scalar_this_for(&kind).expect("repeated message is a CEL list");
+        assert_eq!(
+            ty,
+            CelType::List(Box::new(CelType::MessageRef("test.Child".to_owned())))
+        );
+        let child = MessageSchema {
+            fields: vec![MessageFieldEntry {
+                proto_name: "id".to_owned(),
+                rust_ident: "id".to_owned(),
+                ty: CelType::Str { owned: false },
+                kind: SchemaFieldKind::StringLike,
+            }],
+        };
+        let parent = MessageSchema {
+            fields: vec![MessageFieldEntry {
+                proto_name: "children".to_owned(),
+                rust_ident: "children".to_owned(),
+                ty,
+                kind: SchemaFieldKind::Repeated,
+            }],
+        };
+        let schemas = SchemaIndex::from([("test.Child".to_owned(), child)]);
+        for expression in [
+            "this.children.size() == 0",
+            "this.children.all(s, this.children.filter(t, t.id == s.id).size() == 1)",
+            "this.children.filter(c, c.id != \"\").all(c, this.children.filter(t, t.id == c.id).size() == 1)",
+        ] {
+            let mut compiler = Compiler::new().with_schemas(&schemas);
+            compiler.bind(
+                "this",
+                Binding {
+                    rust_expr: quote! { self },
+                    ty: CelType::Message(Box::new(parent.clone())),
+                    constant: None,
+                },
+            );
+            let output = compiler
+                .compile(expression)
+                .expect("message-list CEL compiles");
+            assert_eq!(output.ty, CelType::Bool);
         }
     }
 }

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel_compile.rs
@@ -201,6 +201,14 @@ pub struct MessageFieldEntry {
 /// access shape. Mirrors a subset of `scan::FieldKind`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SchemaFieldKind {
+    /// A real oneof alternative has presence even when its value is default.
+    Oneof {
+        accessor: String,
+        module: String,
+        enumeration: String,
+        variant: String,
+        view: bool,
+    },
     /// Singular scalar / enum / bool — `has()` returns true iff non-default.
     Scalar,
     /// String / bytes — `has()` returns true iff non-empty.
@@ -3935,6 +3943,11 @@ fn select_message_field(
         .ok_or_else(|| FallbackReason::new(format!("unknown field: {field}")))?;
     let rust_ident = crate::emit::field_ident(&entry.rust_ident);
     let access = match &entry.kind {
+        SchemaFieldKind::Oneof { .. } => {
+            return Err(FallbackReason::new(
+                "oneof value access requires a variant projection",
+            ));
+        }
         SchemaFieldKind::StringLike => match &entry.ty {
             CelType::Str { .. } => {
                 quote! { (::core::convert::AsRef::<str>::as_ref(&#operand.#rust_ident)) }
@@ -4050,6 +4063,24 @@ fn has_message_field(
         .ok_or_else(|| FallbackReason::new(format!("unknown field for has: {field}")))?;
     let rust_ident = crate::emit::field_ident(&entry.rust_ident);
     let tokens = match &entry.kind {
+        SchemaFieldKind::Oneof {
+            accessor,
+            module,
+            enumeration,
+            variant,
+            view,
+        } => {
+            let accessor = crate::emit::field_ident(accessor);
+            let module = crate::emit::field_ident(module);
+            let enumeration = crate::emit::field_ident(enumeration);
+            let variant = crate::emit::field_ident(variant);
+            let root = if *view {
+                quote! { __buffa::view::oneof }
+            } else {
+                quote! { __buffa::oneof }
+            };
+            quote! { matches!(&#operand.#accessor, Some(#root::#module::#enumeration::#variant(_))) }
+        }
         SchemaFieldKind::Scalar => match &entry.ty {
             CelType::Int => {
                 quote! { (::protovalidate_buffa::cel::CelScalar::cel_int(#operand.#rust_ident) != 0i64) }
@@ -4108,6 +4139,33 @@ mod tests {
     //! string contains-checks (we don't pin exact whitespace because
     //! quote! formatting is implementation-detail).
     use super::*;
+
+    #[test]
+    fn oneof_presence_matches_the_selected_variant_for_owned_and_view_messages() {
+        for view in [false, true] {
+            let schema = MessageSchema {
+                fields: vec![MessageFieldEntry {
+                    proto_name: "produced".to_owned(),
+                    rust_ident: "produced".to_owned(),
+                    ty: CelType::Dyn,
+                    kind: SchemaFieldKind::Oneof {
+                        accessor: "origin".to_owned(),
+                        module: "source".to_owned(),
+                        enumeration: "Origin".to_owned(),
+                        variant: "Produced".to_owned(),
+                        view,
+                    },
+                }],
+            };
+            let output =
+                compile_with_this("has(this.produced)", CelType::Message(Box::new(schema)));
+            let code = output.tokens.to_string();
+            assert!(code.contains("__this . origin"));
+            assert!(code.contains("Origin :: Produced"));
+            assert_eq!(code.contains("__buffa :: view :: oneof"), view);
+            assert!(!code.contains("produced . is_set"));
+        }
+    }
 
     fn compile_with_this(expr: &str, this_ty: CelType) -> CompileOutput {
         let mut c = Compiler::new();

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
@@ -408,7 +408,8 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
             .iter()
             .map(|f| {
                 let inner = field::emit(f, schemas, shape)?;
-                if implicit_ignore.contains(f.field_name.as_str())
+                if !inner.is_empty()
+                    && implicit_ignore.contains(f.field_name.as_str())
                     && !matches!(f.ignore, crate::scan::Ignore::Always)
                 {
                     let accessor = field_ident(&f.field_name);
@@ -475,10 +476,15 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
         .collect::<Result<_>>()?;
 
     // `(buf.validate.message).oneof` — fields where at most one may be set.
-    let message_oneof_blocks: Vec<TokenStream> = msg
+    let owned_message_oneof_blocks: Vec<TokenStream> = msg
         .message_oneofs
         .iter()
-        .map(|spec| emit_message_oneof(msg, spec))
+        .map(|spec| emit_message_oneof(msg, spec, Shape::Owned))
+        .collect();
+    let view_message_oneof_blocks: Vec<TokenStream> = msg
+        .message_oneofs
+        .iter()
+        .map(|spec| emit_message_oneof(msg, spec, Shape::View))
         .collect();
 
     let (cel_statics, owned_cel_calls) = cel::emit_message_level(msg, schemas, Shape::Owned);
@@ -518,6 +524,7 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
                        map_bindings: &[TokenStream],
                        field_blocks: &[TokenStream],
                        oneof_blocks: &[TokenStream],
+                       message_oneof_blocks: &[TokenStream],
                        cel_calls: &[TokenStream]| {
         quote! {
             #allows
@@ -565,6 +572,7 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
             &owned_map_bindings,
             &owned_field_blocks,
             &oneof_blocks,
+            &owned_message_oneof_blocks,
             &owned_cel_calls,
         ),
         render_impl(
@@ -572,6 +580,7 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
             &view_map_bindings,
             &view_field_blocks,
             &view_oneof_blocks,
+            &view_message_oneof_blocks,
             &view_cel_calls,
         ),
     ];
@@ -581,18 +590,13 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
     })
 }
 
-/// Strip the package prefix from a fully-qualified proto name.
-///
-/// `"test.v1.ScalarsMessage"` with package `"test.v1"` → `"ScalarsMessage"`.
-/// `"example.v1.Outer.Inner"` with package `"example.v1"` → `"Outer.Inner"`.
-/// If `package` is empty or the name does not start with `<package>.`, return
-/// the original name unchanged.
 /// Emit a `(buf.validate.message).oneof` rule. Counts how many listed fields
 /// are considered "set"; emits `message.oneof` violation if zero (only when
 /// required) or more than one.
 fn emit_message_oneof(
     msg: &crate::scan::MessageValidators,
     spec: &crate::scan::MessageOneofSpec,
+    shape: Shape,
 ) -> TokenStream {
     use crate::scan::FieldKind;
     let checks: Vec<TokenStream> = spec
@@ -601,30 +605,50 @@ fn emit_message_oneof(
         .filter_map(|name| {
             let fv = msg.field_rules.iter().find(|f| &f.field_name == name)?;
             let ident = field_ident(&fv.field_name);
-            // "Set" semantics per protovalidate-go for message.oneof:
-            // messages: present; repeated/map: non-empty; proto3 optional: is_some;
-            // scalar: always counted as set (we can't distinguish default from unset).
-            let expr = match &fv.field_type {
-                FieldKind::Message { .. } | FieldKind::Wrapper(_) => {
-                    quote! { self.#ident.is_set() }
+            // Explicit-presence fields count when present, even with a default
+            // value. Fields without presence count when non-default.
+            let expr = if let Some(oneof_name) = &fv.oneof_name {
+                let oneof = msg
+                    .oneof_rules
+                    .iter()
+                    .find(|oneof| &oneof.name == oneof_name)?;
+                let accessor = field_ident(oneof_name);
+                let module = field_ident(&oneof::to_snake_case(&oneof.parent_msg_name));
+                let enumeration = field_ident(&oneof::to_pascal_case(oneof_name));
+                let variant = field_ident(&oneof::to_pascal_case(&fv.field_name));
+                let oneof_root = match shape {
+                    Shape::Owned => quote! { __buffa::oneof },
+                    Shape::View => quote! { __buffa::view::oneof },
+                };
+                quote! {
+                    matches!(
+                        &self.#accessor,
+                        Some(#oneof_root::#module::#enumeration::#variant(_))
+                    )
                 }
-                FieldKind::Repeated(_) | FieldKind::Map { .. } => {
-                    quote! { !self.#ident.is_empty() }
+            } else {
+                match &fv.field_type {
+                    FieldKind::Message { .. } | FieldKind::Wrapper(_) => {
+                        quote! { self.#ident.is_set() }
+                    }
+                    FieldKind::Repeated(_) | FieldKind::Map { .. } => {
+                        quote! { !self.#ident.is_empty() }
+                    }
+                    FieldKind::Optional(_) => quote! { self.#ident.is_some() },
+                    FieldKind::String | FieldKind::Bytes => quote! { !self.#ident.is_empty() },
+                    FieldKind::Bool => quote! { self.#ident },
+                    FieldKind::Int32 | FieldKind::Sint32 | FieldKind::Sfixed32 => {
+                        quote! { self.#ident != 0i32 }
+                    }
+                    FieldKind::Int64 | FieldKind::Sint64 | FieldKind::Sfixed64 => {
+                        quote! { self.#ident != 0i64 }
+                    }
+                    FieldKind::Uint32 | FieldKind::Fixed32 => quote! { self.#ident != 0u32 },
+                    FieldKind::Uint64 | FieldKind::Fixed64 => quote! { self.#ident != 0u64 },
+                    FieldKind::Float => quote! { self.#ident != 0f32 },
+                    FieldKind::Double => quote! { self.#ident != 0f64 },
+                    FieldKind::Enum { .. } => quote! { (self.#ident as i32) != 0i32 },
                 }
-                FieldKind::Optional(_) => quote! { self.#ident.is_some() },
-                FieldKind::String | FieldKind::Bytes => quote! { !self.#ident.is_empty() },
-                FieldKind::Bool => quote! { self.#ident },
-                FieldKind::Int32 | FieldKind::Sint32 | FieldKind::Sfixed32 => {
-                    quote! { self.#ident != 0i32 }
-                }
-                FieldKind::Int64 | FieldKind::Sint64 | FieldKind::Sfixed64 => {
-                    quote! { self.#ident != 0i64 }
-                }
-                FieldKind::Uint32 | FieldKind::Fixed32 => quote! { self.#ident != 0u32 },
-                FieldKind::Uint64 | FieldKind::Fixed64 => quote! { self.#ident != 0u64 },
-                FieldKind::Float => quote! { self.#ident != 0f32 },
-                FieldKind::Double => quote! { self.#ident != 0f64 },
-                FieldKind::Enum { .. } => quote! { (self.#ident as i32) != 0i32 },
             };
             Some(quote! { if #expr { __count += 1; } })
         })
@@ -671,6 +695,12 @@ fn snake_from_pascal(s: &str) -> String {
     out
 }
 
+/// Strip the package prefix from a fully-qualified proto name.
+///
+/// `"test.v1.ScalarsMessage"` with package `"test.v1"` → `"ScalarsMessage"`.
+/// `"example.v1.Outer.Inner"` with package `"example.v1"` → `"Outer.Inner"`.
+/// If `package` is empty or the name does not start with `<package>.`, return
+/// the original name unchanged.
 fn strip_package_prefix<'a>(proto_name: &'a str, package: &str) -> &'a str {
     if package.is_empty() {
         return proto_name;

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
@@ -987,7 +987,7 @@ fn oneof_field_path(f: &FieldValidator) -> TokenStream {
     }
 }
 
-fn to_snake_case(s: &str) -> String {
+pub(super) fn to_snake_case(s: &str) -> String {
     let chars: Vec<char> = s.chars().collect();
     let mut out = String::with_capacity(s.len() + 2);
     for (i, &c) in chars.iter().enumerate() {
@@ -1004,7 +1004,7 @@ fn to_snake_case(s: &str) -> String {
 }
 
 /// Convert `snake_case` to `PascalCase` (for buffa enum variant/type names).
-fn to_pascal_case(s: &str) -> String {
+pub(super) fn to_pascal_case(s: &str) -> String {
     s.split('_')
         .map(|part| {
             let mut chars = part.chars();

--- a/crates/protovalidate-buffa-conformance/build.rs
+++ b/crates/protovalidate-buffa-conformance/build.rs
@@ -207,6 +207,7 @@ fn enabled_case_files() -> Vec<String> {
         "wkt_field_mask.proto",
         "wkt_nested.proto",
         "cel_message_wkt.proto",
+        "cel_oneof.proto",
         "ignore_proto2.proto",
         "ignore_empty_proto2.proto",
         "required_field_proto2.proto",

--- a/crates/protovalidate-buffa-conformance/proto/buf/validate/conformance/cases/cel_oneof.proto
+++ b/crates/protovalidate-buffa-conformance/proto/buf/validate/conformance/cases/cel_oneof.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package buf.validate.conformance.cases;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+message CelOneofPresence {
+  option (buf.validate.message).cel = {
+    id: "oneof.presence"
+    expression: "has(this.number) == (this.selected == 1) && has(this.text) == (this.selected == 2) && has(this.child) == (this.selected == 3) && has(this.stamp) == (this.selected == 4)"
+  };
+
+  int32 selected = 1;
+  oneof choice {
+    int32 number = 2;
+    string text = 3;
+    CelOneofChild child = 4;
+    google.protobuf.Timestamp stamp = 5;
+  }
+}
+
+message CelOneofChild {
+  string id = 1;
+}
+
+message CelOneofContainer {
+  option (buf.validate.message).cel = {
+    id: "oneof.message_list"
+    expression: "this.many.all(v, has(v.number))"
+  };
+
+  CelOneofPresence single = 1 [(buf.validate.field).cel = {
+    id: "oneof.field"
+    expression: "has(this.number)"
+  }];
+  repeated CelOneofPresence many = 2 [(buf.validate.field).cel = {
+    id: "oneof.field_list"
+    expression: "this.all(v, has(v.number))"
+  }];
+}
+
+message MessageOneofPresence {
+  option (buf.validate.message).oneof = {
+    fields: [
+      "number",
+      "text",
+      "outside"
+    ]
+    required: true
+  };
+
+  oneof choice {
+    int32 number = 1;
+    string text = 2;
+  }
+  string outside = 3;
+}
+
+message CelMessageTree {
+  option (buf.validate.message).cel = {
+    id: "tree.unique_children"
+    expression: "this.children.all(c, this.children.filter(t, t.id == c.id).size() == 1)"
+  };
+
+  string id = 1;
+  repeated CelMessageTree children = 2;
+}

--- a/crates/protovalidate-buffa-conformance/tests/cel_oneof.rs
+++ b/crates/protovalidate-buffa-conformance/tests/cel_oneof.rs
@@ -1,0 +1,153 @@
+#![warn(rust_2018_idioms)]
+
+use buffa::{Message as _, MessageView as _};
+use protovalidate_buffa::{Validate as _, ValidationError};
+
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    dead_code,
+    elided_lifetimes_in_paths,
+    non_camel_case_types,
+    unused_imports,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::invalid_html_tags,
+    reason = "buffa-build generated code"
+)]
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/_include.rs"));
+}
+
+use generated::buf::validate::conformance::cases::{
+    __buffa::{oneof, view},
+    CelMessageTree, CelOneofChild, CelOneofContainer, CelOneofPresence, MessageOneofPresence,
+};
+
+fn assert_rules(result: Result<(), ValidationError>, expected: &[&str]) {
+    if expected.is_empty() {
+        assert!(result.is_ok(), "{result:?}");
+    } else {
+        let error = result.expect_err("expected validation violations");
+        assert!(error.compile_error.is_none(), "{error:?}");
+        assert!(error.runtime_error.is_none(), "{error:?}");
+        let rules: Vec<_> = error
+            .violations
+            .iter()
+            .map(|v| v.rule_id.as_ref())
+            .collect();
+        assert_eq!(rules, expected);
+    }
+}
+
+#[test]
+fn selected_oneof_defaults_have_presence() {
+    use oneof::cel_oneof_presence::Choice;
+
+    for (choice, selected) in [
+        (None, 0),
+        (Some(Choice::Number(0)), 1),
+        (Some(Choice::Text(String::new())), 2),
+        (Some(Choice::Child(CelOneofChild::default().into())), 3),
+        (Some(Choice::Stamp(Box::default())), 4),
+    ] {
+        for claimed in 0..=4 {
+            let owned = CelOneofPresence {
+                choice: choice.clone(),
+                selected: claimed,
+                ..Default::default()
+            };
+            let bytes = owned.encode_to_vec();
+            let borrowed = view::CelOneofPresenceView::decode_view(&bytes).unwrap();
+            let rules: &[&str] = if claimed == selected {
+                &[]
+            } else {
+                &["oneof.presence"]
+            };
+            assert_rules(owned.validate(), rules);
+            assert_rules(borrowed.validate(), rules);
+        }
+    }
+}
+
+#[test]
+fn nested_and_repeated_oneofs_use_the_correct_representation() {
+    use oneof::cel_oneof_presence::Choice;
+
+    for valid in [false, true] {
+        let child = CelOneofPresence {
+            choice: Some(if valid {
+                Choice::Number(0)
+            } else {
+                Choice::Text(String::new())
+            }),
+            selected: if valid { 1 } else { 2 },
+            ..Default::default()
+        };
+        let owned = CelOneofContainer {
+            single: child.clone().into(),
+            many: vec![child],
+            ..Default::default()
+        };
+        let bytes = owned.encode_to_vec();
+        let borrowed = view::CelOneofContainerView::decode_view(&bytes).unwrap();
+        let rules: &[&str] = if valid {
+            &[]
+        } else {
+            &["oneof.message_list", "oneof.field", "oneof.field_list"]
+        };
+        assert_rules(owned.validate(), rules);
+        assert_rules(borrowed.validate(), rules);
+    }
+}
+
+#[test]
+fn message_oneof_counts_selected_default_values() {
+    use oneof::message_oneof_presence::Choice;
+
+    for choice in [
+        None,
+        Some(Choice::Number(0)),
+        Some(Choice::Text(String::new())),
+    ] {
+        for outside in ["", "set"] {
+            let valid = choice.is_some() == outside.is_empty();
+            let owned = MessageOneofPresence {
+                choice: choice.clone(),
+                outside: outside.to_string(),
+                ..Default::default()
+            };
+            let bytes = owned.encode_to_vec();
+            let borrowed = view::MessageOneofPresenceView::decode_view(&bytes).unwrap();
+            let rules: &[&str] = if valid { &[] } else { &["message.oneof"] };
+            assert_rules(owned.validate(), rules);
+            assert_rules(borrowed.validate(), rules);
+        }
+    }
+}
+
+#[test]
+fn recursive_message_lists_resolve_element_schemas() {
+    for ids in [vec![], vec!["a"], vec!["a", "b"], vec!["a", "a"]] {
+        let valid = ids != ["a", "a"];
+        let owned = CelMessageTree {
+            children: ids
+                .into_iter()
+                .map(|id| CelMessageTree {
+                    id: id.to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let bytes = owned.encode_to_vec();
+        let borrowed = view::CelMessageTreeView::decode_view(&bytes).unwrap();
+        let rules: &[&str] = if valid {
+            &[]
+        } else {
+            &["tree.unique_children"]
+        };
+        assert_rules(owned.validate(), rules);
+        assert_rules(borrowed.validate(), rules);
+    }
+}


### PR DESCRIPTION
Fix oneof presence handling throughout CEL code generation.

The scanner models real oneof alternatives as fields, but Buffa stores them in a parent `Option<OneofEnum>`. The generator consequently emitted direct field accesses for `has(this.variant)` and for message-level `oneof` guards. This either failed to compile or treated default-valued alternatives as absent.

This change carries oneof metadata into CEL schemas, emits owned/view enum-variant matches for presence, skips invalid direct guards, and keeps repeated/recursive message references resolvable through the schema index. Conformance fixtures cover scalar, string, message, WKT, nested, repeated, recursive, and message-level oneof cases for both representations.

Validation:

- `cargo test --locked --workspace --all-targets`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `hk check --all --slow`
