### PR TITLE
feat(codegen)!: support idiomatic field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ Add to your `buf.gen.yaml`:
   strategy: all
 ```
 
+If buffa uses `idiomatic_field_names`, enable it on the validator plugin too:
+
+```yaml
+- local: protoc-gen-buffa
+  out: gen/proto
+  strategy: all
+  opt: [idiomatic_field_names=true]
+- local: protoc-gen-protovalidate-buffa
+  out: gen/protovalidate
+  strategy: all
+  opt: [idiomatic_field_names=true]
+```
+
+The bare `idiomatic_field_names` flag also enables it; the default and
+`idiomatic_field_names=false` preserve protobuf field spelling. Use the same
+input descriptors and generation strategy for both plugins: buffa resolves
+collisions across the entire request, including imports. Rust accessors follow
+buffa's conversion and collision rules, while CEL expressions and validation
+error paths keep the original protobuf names. Oneof enum and variant names are
+unaffected.
+
+For in-process generation, set `CodeGeneratorRequest.parameter` before calling
+`scan::gather`, for example `Some("idiomatic_field_names=true".into())`. Then pass
+the scanned validators to `emit::render` or `emit::render_with_options` as usual.
+
 Annotate a proto (see upstream for the full rule vocabulary):
 
 ```protobuf

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/cel.rs
@@ -71,7 +71,7 @@ pub(crate) fn emit_message_level(
         if is_unsupported_wkt_field_for_cel(&f.field_type) {
             continue;
         }
-        let field_ident = crate::emit::field_ident(&f.field_name);
+        let field_ident = crate::emit::field_ident(&f.rust_name);
         let field_name = &f.field_name;
         let fnum = f.field_number;
         // For repeated scalars the CEL rule path uses the element type; for
@@ -146,7 +146,7 @@ pub(crate) fn emit_message_level(
             continue;
         }
         let default_family = predef_family_for(&f.field_type);
-        let field_ident = crate::emit::field_ident(&f.field_name);
+        let field_ident = crate::emit::field_ident(&f.rust_name);
         let field_name = &f.field_name;
         let fnum = f.field_number;
         for rule in &f.standard.predefined {
@@ -1000,7 +1000,7 @@ fn build_message_schema(msg: &MessageValidators) -> MessageSchema {
                     .any(|candidate| candidate.field_number == field.field_number)
             }) {
                 entry.kind = SchemaFieldKind::Oneof {
-                    accessor: oneof.name.clone(),
+                    accessor: oneof.rust_name.clone(),
                     module: super::oneof::to_snake_case(&oneof.parent_msg_name),
                     enumeration: super::oneof::to_pascal_case(&oneof.name),
                     variant: super::oneof::to_pascal_case(&field.field_name),
@@ -1015,7 +1015,7 @@ fn build_message_schema(msg: &MessageValidators) -> MessageSchema {
 
 fn field_to_schema_entry(f: &FieldValidator) -> Option<MessageFieldEntry> {
     let proto_name = f.field_name.clone();
-    let rust_ident = f.field_name.clone();
+    let rust_ident = f.rust_name.clone();
     let (ty, kind) = match &f.field_type {
         FieldKind::String => (CelType::Str { owned: false }, SchemaFieldKind::StringLike),
         FieldKind::Bytes => (CelType::Bytes { owned: false }, SchemaFieldKind::StringLike),

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/field.rs
@@ -40,7 +40,7 @@ pub(crate) fn emit(
         return Ok(quote! {});
     }
 
-    let accessor = crate::emit::field_ident(&field.field_name);
+    let accessor = crate::emit::field_ident(&field.rust_name);
     let name_lit = &field.field_name;
     let mut blocks: Vec<TokenStream> = Vec::new();
 

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
@@ -85,7 +85,7 @@ fn canonical_map_bindings(msg: &MessageValidators, shape: Shape) -> Vec<TokenStr
         .iter()
         .filter(|field| needs_canonical_map(field))
         .map(|field| {
-            let accessor = field_ident(&field.field_name);
+            let accessor = field_ident(&field.rust_name);
             let binding = canonical_map_ident(field.field_number);
             quote! {
                 let #binding =
@@ -413,7 +413,7 @@ fn render_message(msg: &MessageValidators, schemas: &cel::SchemaIndex) -> Result
                     && implicit_ignore.contains(f.field_name.as_str())
                     && !matches!(f.ignore, crate::scan::Ignore::Always)
                 {
-                    let accessor = field_ident(&f.field_name);
+                    let accessor = field_ident(&f.rust_name);
                     let guard: Option<TokenStream> = match &f.field_type {
                         crate::scan::FieldKind::String | crate::scan::FieldKind::Bytes => {
                             Some(quote! { !self.#accessor.is_empty() })
@@ -605,7 +605,7 @@ fn emit_message_oneof(
         .iter()
         .filter_map(|name| {
             let fv = msg.field_rules.iter().find(|f| &f.field_name == name)?;
-            let ident = field_ident(&fv.field_name);
+            let ident = field_ident(&fv.rust_name);
             // Explicit-presence fields count when present, even with a default
             // value. Fields without presence count when non-default.
             let expr = if let Some(oneof_name) = &fv.oneof_name {
@@ -613,7 +613,7 @@ fn emit_message_oneof(
                     .oneof_rules
                     .iter()
                     .find(|oneof| &oneof.name == oneof_name)?;
-                let accessor = field_ident(oneof_name);
+                let accessor = field_ident(&oneof.rust_name);
                 let module = field_ident(&oneof::to_snake_case(&oneof.parent_msg_name));
                 let enumeration = field_ident(&oneof::to_pascal_case(oneof_name));
                 let variant = field_ident(&oneof::to_pascal_case(&fv.field_name));

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/oneof.rs
@@ -41,7 +41,7 @@ fn emit_for(v: &OneofValidator, representation: Representation) -> Result<TokenS
         return Ok(quote! {});
     }
 
-    let accessor = crate::emit::field_ident(&v.name);
+    let accessor = crate::emit::field_ident(&v.rust_name);
     let name_lit = &v.name;
 
     // The module name buffa generates for a message's oneof is the snake_case of

--- a/crates/protoc-gen-protovalidate-buffa/src/scan.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/scan.rs
@@ -26,6 +26,8 @@ use protovalidate_buffa_protos::buf::validate::{
     SFixed64Rules, SInt32Rules, SInt64Rules, StringRules, UInt32Rules, UInt64Rules,
 };
 
+mod field_names;
+
 // ─── Public output types ──────────────────────────────────────────────────────
 
 /// All validators collected for a single protobuf message.
@@ -55,6 +57,8 @@ pub struct MessageValidators {
 pub struct FieldValidator {
     pub field_number: i32,
     pub field_name: String,
+    /// Rust accessor name before keyword escaping; protobuf paths use `field_name`.
+    pub rust_name: String,
     pub field_type: FieldKind,
     /// `(buf.validate.field).required`
     pub required: bool,
@@ -89,6 +93,8 @@ pub struct FieldValidator {
 #[derive(Debug)]
 pub struct OneofValidator {
     pub name: String,
+    /// Rust struct field name; the enum type still derives from `name`.
+    pub rust_name: String,
     pub required: bool,
     /// The parent message name (e.g. `"CreateGradingRequest"`), used to derive the
     /// buffa-generated module name for the oneof enum type.
@@ -969,12 +975,32 @@ fn varint_decode(buf: &[u8]) -> Option<(u64, &[u8])> {
 /// Walk a `CodeGeneratorRequest` and return one `MessageValidators` per
 /// message (including nested) in every file listed in `file_to_generate`.
 ///
+/// Set `request.parameter` to `idiomatic_field_names=true` (or the bare flag)
+/// when buffa uses that option. Naming collisions are planned across all
+/// `proto_file` descriptors, including imports, just as in buffa. The default
+/// and `idiomatic_field_names=false` preserve protobuf spelling.
+///
+/// # Examples
+///
+/// ```
+/// use buffa_codegen::generated::compiler::CodeGeneratorRequest;
+/// use protoc_gen_protovalidate_buffa::scan::gather;
+/// let request = CodeGeneratorRequest {
+///     parameter: Some("idiomatic_field_names=true".into()),
+///     ..Default::default()
+/// };
+/// assert!(gather(&request)?.is_empty());
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+///
 /// # Errors
 ///
 /// Returns an error if a field's type cannot be classified, if an unsupported
-/// rule family (e.g. `Any`, `Duration`) is encountered, or if a proto type
+/// rule family (e.g. `Any`, `Duration`) is encountered, if the naming option
+/// is not a boolean, or if a proto type
 /// cannot be parsed into the expected format.
 pub fn gather(request: &CodeGeneratorRequest) -> anyhow::Result<Vec<MessageValidators>> {
+    let idiomatic = idiomatic_field_names(request.parameter.as_deref().unwrap_or(""))?;
     let generate_set: std::collections::HashSet<&str> = request
         .file_to_generate
         .iter()
@@ -1004,7 +1030,31 @@ pub fn gather(request: &CodeGeneratorRequest) -> anyhow::Result<Vec<MessageValid
             )?;
         }
     }
+    if idiomatic {
+        let names = field_names::FieldNames::new(&request.proto_file);
+        for message in &mut out {
+            names.apply(message);
+        }
+    }
     Ok(out)
+}
+
+fn idiomatic_field_names(parameter: &str) -> anyhow::Result<bool> {
+    let mut enabled = false;
+    for part in parameter.split(',') {
+        let part = part.trim();
+        let (key, value) = part.split_once('=').unwrap_or((part, "true"));
+        if key.trim() == "idiomatic_field_names" {
+            enabled = match value.trim() {
+                "true" => true,
+                "false" => false,
+                value => {
+                    anyhow::bail!("idiomatic_field_names must be true or false, got {value:?}")
+                }
+            };
+        }
+    }
+    Ok(enabled)
 }
 
 // ─── Message recursion ───────────────────────────────────────────────────────
@@ -1439,6 +1489,7 @@ fn gather_field(
     Ok(FieldValidator {
         field_number: field.number.unwrap_or(0),
         field_name: field.name.as_deref().unwrap_or("").to_string(),
+        rust_name: field.name.as_deref().unwrap_or("").to_string(),
         field_type,
         required,
         ignore,
@@ -1467,6 +1518,7 @@ fn gather_oneof(
 
     OneofValidator {
         name: oneof.name.as_deref().unwrap_or("").to_string(),
+        rust_name: oneof.name.as_deref().unwrap_or("").to_string(),
         required,
         parent_msg_name: parent_msg_name.to_string(),
         fields,
@@ -2265,6 +2317,7 @@ fn parse_inner_field(
     Ok(FieldValidator {
         field_number: -1,
         field_name: std::string::String::new(),
+        rust_name: std::string::String::new(),
         field_type: FieldKind::String, // placeholder — no descriptor for inner rules
         required,
         ignore,

--- a/crates/protoc-gen-protovalidate-buffa/src/scan/field_names.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/scan/field_names.rs
@@ -1,0 +1,158 @@
+//! Match buffa 0.9's private `field_names` planner and insertion-only converter.
+//!
+//! Source: <https://github.com/anthropics/buffa/blob/v0.9.1/buffa-codegen/src/field_names.rs>.
+//! Exceptions are shared across the entire descriptor set by (name, number),
+//! including imports. Verbatim fallback takes precedence over a numbered suffix.
+//! Keep this in step with buffa upgrades; the conformance fixtures compile both
+//! generators' output together to detect drift. Proto names remain untouched.
+
+use std::collections::{HashMap, HashSet};
+
+use buffa_codegen::generated::descriptor::{DescriptorProto, FileDescriptorProto};
+
+use super::MessageValidators;
+
+#[derive(Default)]
+pub(super) struct FieldNames {
+    /// Field exceptions before Rust keyword escaping.
+    fields: HashMap<(String, i32), String>,
+    /// Oneof names whose conversion collides anywhere in the request.
+    verbatim_oneofs: HashSet<String>,
+}
+
+impl FieldNames {
+    pub(super) fn new(files: &[FileDescriptorProto]) -> Self {
+        let mut names = Self::default();
+        for file in files {
+            for message in &file.message_type {
+                names.plan_message(message);
+            }
+        }
+        names
+    }
+
+    fn plan_message(&mut self, message: &DescriptorProto) {
+        if message
+            .options
+            .as_option()
+            .is_some_and(|o| o.map_entry == Some(true))
+        {
+            return;
+        }
+        for nested in &message.nested_type {
+            self.plan_message(nested);
+        }
+
+        // Real oneof variants do not occupy the struct's field namespace.
+        // Proto3 optional fields do; their synthetic oneofs do not.
+        let mut real_oneofs = HashSet::new();
+        let mut members = Vec::new();
+        for field in &message.field {
+            let Some(name) = field.name.as_deref() else {
+                continue;
+            };
+            if let Some(index) = field.oneof_index
+                && !field.proto3_optional.unwrap_or(false)
+            {
+                real_oneofs.insert(index);
+                continue;
+            }
+            members.push((name, Some(field.number.unwrap_or(0)), snake_case(name)));
+        }
+        for (index, oneof) in message.oneof_decl.iter().enumerate() {
+            if real_oneofs.contains(&(index as i32))
+                && let Some(name) = oneof.name.as_deref()
+            {
+                members.push((name, None, snake_case(name)));
+            }
+        }
+
+        let mut counts = HashMap::new();
+        for (_, _, converted) in &members {
+            *counts.entry(converted.as_str()).or_insert(0usize) += 1;
+        }
+        let mut finals: Vec<String> = members
+            .iter()
+            .map(|(name, number, converted)| {
+                if counts[converted.as_str()] > 1 && converted != name {
+                    number.map_or_else(|| (*name).to_string(), |n| format!("{converted}_f{n}"))
+                } else {
+                    converted.clone()
+                }
+            })
+            .collect();
+
+        // A suffix may collide with a literal name. Buffa then reverts EVERY
+        // changed member of this message, including unrelated conversions.
+        if finals.iter().collect::<HashSet<_>>().len() != finals.len() {
+            for ((name, _, converted), resolved) in members.iter().zip(&mut finals) {
+                if converted != name {
+                    *resolved = (*name).to_string();
+                }
+            }
+        }
+        for ((name, number, converted), resolved) in members.into_iter().zip(finals) {
+            if resolved == converted {
+                continue;
+            }
+            if let Some(number) = number {
+                let entry = self
+                    .fields
+                    .entry((name.to_string(), number))
+                    .or_insert_with(|| resolved.clone());
+                if resolved == name {
+                    *entry = resolved;
+                }
+            } else {
+                self.verbatim_oneofs.insert(name.to_string());
+            }
+        }
+    }
+
+    pub(super) fn apply(&self, message: &mut MessageValidators) {
+        for field in message.field_rules.iter_mut().chain(
+            message
+                .oneof_rules
+                .iter_mut()
+                .flat_map(|oneof| &mut oneof.fields),
+        ) {
+            field.rust_name = self
+                .fields
+                .get(&(field.field_name.clone(), field.field_number))
+                .cloned()
+                .unwrap_or_else(|| snake_case(&field.field_name));
+        }
+        for oneof in &mut message.oneof_rules {
+            oneof.rust_name = if self.verbatim_oneofs.contains(&oneof.name) {
+                oneof.name.clone()
+            } else {
+                snake_case(&oneof.name)
+            };
+        }
+    }
+}
+
+fn snake_case(name: &str) -> String {
+    let mut chars = name.chars().peekable();
+    let mut result = String::with_capacity(name.len());
+    let mut last_cased: Option<char> = None;
+    while let Some(c) = chars.next() {
+        if c == '_' {
+            last_cased = None;
+            result.push(c);
+            continue;
+        }
+        if c.is_uppercase()
+            && last_cased.is_some_and(|previous| {
+                previous.is_lowercase() || chars.peek().is_some_and(|next| next.is_lowercase())
+            })
+        {
+            result.push('_');
+        }
+        result.extend(c.to_lowercase());
+        if c.is_lowercase() || c.is_uppercase() {
+            last_cased = Some(c);
+        }
+    }
+    result
+}

--- a/crates/protoc-gen-protovalidate-buffa/tests/keyword_idents.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/keyword_idents.rs
@@ -30,6 +30,7 @@ fn field(name: &str, field_type: FieldKind) -> FieldValidator {
     FieldValidator {
         field_number: 1,
         field_name: name.to_string(),
+        rust_name: name.to_string(),
         field_type,
         required: false,
         ignore: Ignore::Unspecified,
@@ -102,6 +103,7 @@ fn required_oneof_named_type_uses_raw_ident() {
     let mut msg = message(Vec::new());
     msg.oneof_rules = vec![OneofValidator {
         name: "type".to_string(),
+        rust_name: "type".to_string(),
         required: true,
         parent_msg_name: "M".to_string(),
         fields: Vec::new(),

--- a/crates/protoc-gen-protovalidate-buffa/tests/optional_string_pattern.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/optional_string_pattern.rs
@@ -33,6 +33,7 @@ fn string_field_with_pattern(field_type: FieldKind) -> FieldValidator {
     FieldValidator {
         field_number: 1,
         field_name: "name".to_string(),
+        rust_name: "name".to_string(),
         field_type,
         required: false,
         ignore: Ignore::Unspecified,
@@ -86,6 +87,7 @@ fn oneof_string_pattern_borrows_value() {
 
     let oneof = OneofValidator {
         name: "kind".to_string(),
+        rust_name: "kind".to_string(),
         required: false,
         parent_msg_name: "M".to_string(),
         fields: vec![member],

--- a/crates/protoc-gen-protovalidate-buffa/tests/scan_field_names.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/scan_field_names.rs
@@ -1,0 +1,289 @@
+//! Discussion #53: naming matches buffa across the full request, including
+//! descriptors that are not selected for generation.
+#![warn(rust_2018_idioms)]
+
+use std::{
+    io::Write as _,
+    process::{Command, Stdio},
+};
+
+use buffa::{ExtensionSet as _, Message as _};
+use buffa_codegen::{
+    CodeGenConfig, GeneratedFileKind,
+    generated::{
+        compiler::{CodeGeneratorRequest, CodeGeneratorResponse},
+        descriptor::{
+            DescriptorProto, FieldDescriptorProto, FieldOptions, FileDescriptorProto,
+            OneofDescriptorProto,
+            field_descriptor_proto::{Label, Type},
+        },
+    },
+};
+use protoc_gen_protovalidate_buffa::scan::gather;
+
+fn field(name: &str, number: i32) -> FieldDescriptorProto {
+    FieldDescriptorProto {
+        name: Some(name.to_string()),
+        number: Some(number),
+        label: Some(Label::LABEL_OPTIONAL),
+        r#type: Some(Type::TYPE_STRING),
+        ..Default::default()
+    }
+}
+
+fn message(name: &str, fields: Vec<FieldDescriptorProto>) -> DescriptorProto {
+    DescriptorProto {
+        name: Some(name.into()),
+        field: fields,
+        ..Default::default()
+    }
+}
+
+fn request(messages: Vec<DescriptorProto>) -> CodeGeneratorRequest {
+    CodeGeneratorRequest {
+        file_to_generate: vec!["names.proto".into()],
+        proto_file: vec![FileDescriptorProto {
+            name: Some("names.proto".into()),
+            syntax: Some("proto2".into()),
+            message_type: messages,
+            ..Default::default()
+        }],
+        parameter: Some("idiomatic_field_names".into()),
+        ..Default::default()
+    }
+}
+
+fn rust_names(request: &CodeGeneratorRequest) -> Vec<String> {
+    gather(request)
+        .unwrap()
+        .into_iter()
+        .flat_map(|m| m.field_rules.into_iter().map(|f| f.rust_name))
+        .collect()
+}
+
+#[test]
+fn conversion_matches_buffa_for_acronyms_digits_underscores_and_keywords() {
+    let cases = [
+        ("userName", "user_name"),
+        ("XMLHttpRequest", "xml_http_request"),
+        ("v2Field", "v2_field"),
+        ("XML2Request", "xml2_request"),
+        ("foo_2Bar", "foo_2bar"),
+        ("_fieldName3", "_field_name3"),
+        ("fieldName_", "field_name_"),
+        ("a__B", "a__b"),
+        ("already_snake", "already_snake"),
+        ("Type", "type"),
+        ("Self", "self"),
+    ];
+    for (proto, rust) in cases {
+        let req = request(vec![message("Names", vec![field(proto, 1)])]);
+        assert_eq!(rust_names(&req), [rust], "{proto}");
+        let mut config = CodeGenConfig::default();
+        config.idiomatic_field_names = true;
+        let generated =
+            buffa_codegen::generate(&req.proto_file, &req.file_to_generate, &config).unwrap();
+        let ident = buffa_codegen::idents::make_field_ident(rust);
+        assert!(
+            generated
+                .iter()
+                .filter(|file| file.kind == GeneratedFileKind::Owned)
+                .any(|file| file.content.contains(&format!("pub {ident}:"))),
+            "buffa differs for {proto}"
+        );
+    }
+}
+
+#[test]
+fn collisions_include_imports_nested_messages_and_verbatim_precedence() {
+    let mut req = request(vec![message(
+        "Names",
+        vec![field("userName", 1), field("otherName", 3)],
+    )]);
+    // Imported nested descriptors are deliberately excluded from file_to_generate.
+    req.proto_file.push(FileDescriptorProto {
+        name: Some("import.proto".into()),
+        syntax: Some("proto2".into()),
+        message_type: vec![DescriptorProto {
+            name: Some("Outer".into()),
+            nested_type: vec![
+                message(
+                    "Suffix",
+                    vec![
+                        field("userName", 1),
+                        field("user_name", 2),
+                        field("otherName", 3),
+                        field("other_name", 4),
+                    ],
+                ),
+                message(
+                    "Fallback",
+                    vec![
+                        field("otherName", 3),
+                        field("other_name", 4),
+                        field("other_name_f3", 5),
+                    ],
+                ),
+            ],
+            ..Default::default()
+        }],
+        ..Default::default()
+    });
+    assert_eq!(rust_names(&req), ["user_name_f1", "otherName"]);
+    req.proto_file.reverse();
+    req.proto_file[0].message_type[0].nested_type.reverse();
+    assert_eq!(rust_names(&req), ["user_name_f1", "otherName"]);
+}
+
+#[test]
+fn secondary_collision_reverts_unrelated_conversions_too() {
+    let req = request(vec![message(
+        "Names",
+        vec![
+            field("userName", 1),
+            field("user_name", 2),
+            field("user_name_f1", 3),
+            field("unrelatedName", 4),
+        ],
+    )]);
+    assert_eq!(
+        rust_names(&req),
+        ["userName", "user_name", "user_name_f1", "unrelatedName"]
+    );
+}
+
+#[test]
+fn synthetic_oneofs_and_variant_names_do_not_occupy_struct_namespace() {
+    let mut optional = field("optionalName", 1);
+    optional.oneof_index = Some(1);
+    optional.proto3_optional = Some(true);
+    let mut variant = field("choice_value", 2);
+    variant.oneof_index = Some(0);
+    let mut req = request(vec![DescriptorProto {
+        oneof_decl: vec![
+            OneofDescriptorProto {
+                name: Some("choiceValue".into()),
+                ..Default::default()
+            },
+            OneofDescriptorProto {
+                name: Some("_optionalName".into()),
+                ..Default::default()
+            },
+        ],
+        ..message("Names", vec![optional, variant])
+    }]);
+    req.proto_file[0].syntax = Some("proto3".into());
+    let scanned = gather(&req).unwrap();
+    assert_eq!(scanned[0].field_rules[0].rust_name, "optional_name");
+    assert_eq!(scanned[0].oneof_rules.len(), 1);
+    assert_eq!(scanned[0].oneof_rules[0].rust_name, "choice_value");
+    assert_eq!(
+        scanned[0].oneof_rules[0].fields[0].field_name,
+        "choice_value"
+    );
+}
+
+#[test]
+fn default_false_bare_and_explicit_true_options() {
+    let mut req = request(vec![message("Names", vec![field("userName", 1)])]);
+    for (parameter, expected) in [
+        ("", "userName"),
+        ("idiomatic_field_names=false", "userName"),
+        ("idiomatic_field_names", "user_name"),
+        ("idiomatic_field_names=true", "user_name"),
+        (
+            " proto_module = crate::pb , idiomatic_field_names = true , future_option",
+            "user_name",
+        ),
+        (
+            "idiomatic_field_names=true,idiomatic_field_names=false",
+            "userName",
+        ),
+    ] {
+        req.parameter = Some(parameter.into());
+        assert_eq!(rust_names(&req), [expected]);
+    }
+    req.parameter = None;
+    assert_eq!(rust_names(&req), ["userName"]);
+}
+
+fn invoke_plugin(request: &CodeGeneratorRequest) -> CodeGeneratorResponse {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_protoc-gen-protovalidate-buffa"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(&request.encode_to_vec())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    CodeGeneratorResponse::decode_from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn plugin_accepts_naming_flag_and_reports_invalid_values() {
+    let mut req = request(vec![message("Names", vec![field("userName", 1)])]);
+    let mut options = FieldOptions::default();
+    options.set_extension(
+        &protovalidate_buffa_protos::buf::validate::__buffa::ext::FIELD,
+        protovalidate_buffa_protos::buf::validate::FieldRules {
+            required: Some(true),
+            ..Default::default()
+        },
+    );
+    req.proto_file[0].message_type[0].field[0].options = options.into();
+    let response = invoke_plugin(&req);
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert!(response.file.iter().any(|file| {
+        file.content
+            .as_ref()
+            .is_some_and(|source| source.contains("self.user_name"))
+    }));
+    for parameter in [
+        "idiomatic_field_names=yes",
+        "idiomatic_field_names=",
+        "idiomatic_field_names=1",
+    ] {
+        req.parameter = Some(parameter.into());
+        let error = invoke_plugin(&req)
+            .error
+            .expect("invalid value must fail generation");
+        assert!(error.contains("idiomatic_field_names must be true or false"));
+    }
+}
+
+#[test]
+fn every_changed_member_in_a_collision_gets_its_field_number() {
+    let req = request(vec![message(
+        "Names",
+        vec![field("userName", 1), field("UserName", 2)],
+    )]);
+    assert_eq!(rust_names(&req), ["user_name_f1", "user_name_f2"]);
+}
+
+#[test]
+fn oneofs_inherit_verbatim_fallback_from_imported_descriptors() {
+    let mut member = field("textValue", 1);
+    member.oneof_index = Some(0);
+    let mut choices = message("Choices", vec![member]);
+    choices.oneof_decl.push(OneofDescriptorProto {
+        name: Some("choiceValue".into()),
+        ..Default::default()
+    });
+    let mut req = request(vec![choices.clone()]);
+    choices.field.push(field("choice_value", 2));
+    choices.name = Some("Collision".into());
+    req.proto_file.push(FileDescriptorProto {
+        name: Some("import.proto".into()),
+        message_type: vec![choices],
+        syntax: Some("proto2".into()),
+        ..Default::default()
+    });
+    let scanned = gather(&req).unwrap();
+    assert_eq!(scanned[0].oneof_rules[0].rust_name, "choiceValue");
+    assert_eq!(scanned[0].oneof_rules[0].fields[0].field_name, "textValue");
+}

--- a/crates/protovalidate-buffa-conformance/build.rs
+++ b/crates/protovalidate-buffa-conformance/build.rs
@@ -168,6 +168,81 @@ fn main() {
     // is the verification — any token sequence that doesn't type-check
     // breaks the build.
     write_cel_emit_fixtures(&out_dir);
+    write_field_name_fixtures(&out_dir, &proto_root, &protoc_path, &protoc_include);
+}
+
+/// Compile both generators from the same descriptors in each naming mode.
+fn write_field_name_fixtures(
+    out_dir: &std::path::Path,
+    proto_root: &std::path::Path,
+    protoc: &str,
+    protoc_include: &std::path::Path,
+) {
+    let sources = ["field_names/names.proto", "field_names/collisions.proto"];
+    let fds_path = out_dir.join("field_names.fds");
+    let status = std::process::Command::new(protoc)
+        .arg(format!("--descriptor_set_out={}", fds_path.display()))
+        .arg("--include_imports")
+        .arg(format!("-I{}", proto_root.display()))
+        .arg(format!("-I{}", protoc_include.display()))
+        .args(sources)
+        .status()
+        .expect("run protoc for field-name fixtures");
+    assert!(status.success(), "field-name fixture protoc failed");
+    let fds = FileDescriptorSet::decode_from_slice(
+        &std::fs::read(&fds_path).expect("read naming descriptors"),
+    )
+    .expect("decode naming descriptors");
+    let mut mounts = proc_macro2::TokenStream::new();
+    for (mode, idiomatic) in [("verbatim", false), ("idiomatic", true)] {
+        let directory = out_dir.join("field_names").join(mode);
+        let messages = directory.join("messages");
+        buffa_build::Config::new()
+            .descriptor_set(&fds_path)
+            .files(&sources)
+            .out_dir(&messages)
+            .include_file("mod.rs")
+            .idiomatic_field_names(idiomatic)
+            .compile()
+            .expect("generate buffa field-name fixtures");
+        let request = CodeGeneratorRequest {
+            file_to_generate: sources.iter().map(|s| (*s).to_string()).collect(),
+            proto_file: fds.file.clone(),
+            parameter: Some(format!("idiomatic_field_names={idiomatic}")),
+            ..Default::default()
+        };
+        let scanned = protoc_gen_protovalidate_buffa::scan::gather(&request)
+            .expect("scan field-name fixtures");
+        let options = protoc_gen_protovalidate_buffa::emit::Options {
+            proto_module: format!("crate::{mode}::proto"),
+        };
+        let validators = directory.join("validators");
+        std::fs::create_dir_all(&validators).expect("create naming validators directory");
+        for file in protoc_gen_protovalidate_buffa::emit::render_with_options(&scanned, &options)
+            .expect("render field-name validators")
+        {
+            std::fs::write(
+                validators.join(file.name.expect("generated name")),
+                file.content.expect("generated content"),
+            )
+            .expect("write field-name validators");
+        }
+        let module = quote::format_ident!("{mode}");
+        let messages = messages.join("mod.rs");
+        let messages = messages.to_str().expect("UTF-8 messages path");
+        let validators = validators.join("mod.rs");
+        let validators = validators.to_str().expect("UTF-8 validators path");
+        mounts.extend(quote::quote! {
+            mod #module {
+                #[path = #messages]
+                pub(crate) mod proto;
+                #[path = #validators]
+                mod validators;
+            }
+        });
+    }
+    std::fs::write(out_dir.join("field_name_mounts.rs"), mounts.to_string())
+        .expect("write field-name mounts");
 }
 
 fn write_module_tree_fixtures(

--- a/crates/protovalidate-buffa-conformance/proto/field_names/collisions.proto
+++ b/crates/protovalidate-buffa-conformance/proto/field_names/collisions.proto
@@ -1,0 +1,32 @@
+syntax = "proto2";
+
+package field_names;
+
+import "buf/validate/validate.proto";
+
+message Collision {
+  option (buf.validate.message).cel = {
+    id: "collision.cel"
+    expression: "this.userName != 'blocked'"
+  };
+
+  required string userName = 1 [(buf.validate.field).string.min_len = 2];
+  required string user_name = 2;
+  required string collision_choice = 3;
+  oneof collisionChoice {
+    option (buf.validate.oneof).required = true;
+    string textValue = 4 [(buf.validate.field).string.min_len = 2];
+  }
+}
+
+message Fallback {
+  required string otherName = 11 [(buf.validate.field).string.min_len = 2];
+  required string other_name = 12;
+  required string other_name_f11 = 13;
+  required string unrelatedName = 14 [(buf.validate.field).string.min_len = 2];
+}
+
+message Inherited {
+  required string userName = 1 [(buf.validate.field).string.min_len = 2];
+  required string otherName = 11 [(buf.validate.field).string.min_len = 2];
+}

--- a/crates/protovalidate-buffa-conformance/proto/field_names/names.proto
+++ b/crates/protovalidate-buffa-conformance/proto/field_names/names.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+package field_names;
+
+import "buf/validate/validate.proto";
+
+message Names {
+  option (buf.validate.message).cel = {
+    id: "names.cel"
+    expression: "this.userName != 'blocked' && (!has(this.optionalName) || this.optionalName != 'blocked')"
+  };
+
+  string userName = 1 [(buf.validate.field).string.min_len = 2];
+  optional string optionalName = 2 [(buf.validate.field).string.min_len = 2];
+  repeated string manyNames = 3 [(buf.validate.field).repeated.items.string.min_len = 2];
+  map<string, string> nameMap = 4 [(buf.validate.field).map.values.string.min_len = 2];
+  Child childValue = 5 [(buf.validate.field).cel = {
+    id: "child.cel"
+    expression: "this.displayName != 'blocked'"
+  }];
+  repeated Child manyChildren = 6 [(buf.validate.field).cel = {
+    id: "children.cel"
+    expression: "this.all(c, c.displayName != 'blocked')"
+  }];
+  string XML2Request = 7 [(buf.validate.field).cel = {
+    id: "acronym.cel"
+    expression: "this != 'blocked'"
+  }];
+  string _leadingName_ = 8 [(buf.validate.field).cel = {
+    id: "underscore.cel"
+    expression: "this != 'blocked'"
+  }];
+  string Type = 9 [(buf.validate.field).cel = {
+    id: "keyword.cel"
+    expression: "this != 'blocked'"
+  }];
+  string Self = 10 [(buf.validate.field).cel = {
+    id: "self.cel"
+    expression: "this != 'blocked'"
+  }];
+
+  message Child {
+    string displayName = 1 [(buf.validate.field).string.min_len = 2];
+  }
+}
+
+message Choices {
+  option (buf.validate.message).cel = {
+    id: "choice.cel"
+    expression: "has(this.textValue)"
+  };
+  option (buf.validate.message).oneof = {
+    fields: [
+      "textValue",
+      "outsideValue"
+    ]
+    required: true
+  };
+
+  oneof choiceValue {
+    option (buf.validate.oneof).required = true;
+    string textValue = 1 [(buf.validate.field).string.min_len = 2];
+    int32 numberValue = 2;
+  }
+  string outsideValue = 3 [(buf.validate.field).string.min_len = 2];
+}

--- a/crates/protovalidate-buffa-conformance/tests/emit_field_names.rs
+++ b/crates/protovalidate-buffa-conformance/tests/emit_field_names.rs
@@ -1,0 +1,270 @@
+//! Discussion #53: compile actual buffa types with matching validators in both
+//! naming modes. Decode identical protobuf bytes to check validation behavior
+//! and the original protobuf field spelling in errors, for owned and view types.
+#![warn(rust_2018_idioms)]
+#![allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    dead_code,
+    elided_lifetimes_in_paths,
+    non_camel_case_types,
+    non_snake_case,
+    unused_imports,
+    reason = "generated Buffa and validator modules are compile and behavior fixtures"
+)]
+
+include!(concat!(env!("OUT_DIR"), "/field_name_mounts.rs"));
+
+/// These fixtures only use one-byte tags and payload lengths.
+fn bytes_field(number: u8, value: &[u8]) -> Vec<u8> {
+    assert!(number < 16 && value.len() < 128);
+    let mut bytes = vec![(number << 3) | 2, value.len() as u8];
+    bytes.extend_from_slice(value);
+    bytes
+}
+
+macro_rules! naming_tests {
+    ($mode:ident) => {
+        mod $mode {
+            use crate::bytes_field;
+            use crate::$mode::proto::field_names::{
+                __buffa::view::{
+                    ChoicesView, CollisionView, FallbackView, InheritedView, NamesView,
+                },
+                Choices, Collision, Fallback, Inherited, Names,
+            };
+            use buffa::{Message as _, MessageView as _};
+            use protovalidate_buffa::{Validate, ValidationError};
+
+            fn assert_failure(
+                result: Result<(), ValidationError>,
+                rule: &str,
+                field: Option<&str>,
+            ) {
+                let error = result.expect_err("fixture must fail validation");
+                assert!(error.compile_error.is_none(), "{error:?}");
+                assert!(error.runtime_error.is_none(), "{error:?}");
+                assert!(
+                    error.violations.iter().any(|violation| {
+                        violation.rule_id == rule
+                            && field.is_none_or(|name| {
+                                violation.field.elements[0].field_name.as_deref() == Some(name)
+                            })
+                    }),
+                    "expected {rule} on {field:?}: {error:?}"
+                );
+            }
+
+            // https://github.com/mathematic-inc/protovalidate-buffa/discussions/53
+            #[test]
+            fn scalar_optional_collection_and_nested_names_preserve_paths() {
+                let valid = bytes_field(1, b"ok");
+                assert!(Names::decode_from_slice(&valid).unwrap().validate().is_ok());
+                assert!(NamesView::decode_view(&valid).unwrap().validate().is_ok());
+                for (number, payload, field) in [
+                    (1, b"x".to_vec(), "userName"),
+                    (2, b"x".to_vec(), "optionalName"),
+                    (3, b"x".to_vec(), "manyNames"),
+                    (
+                        4,
+                        [bytes_field(1, b"key"), bytes_field(2, b"x")].concat(),
+                        "nameMap",
+                    ),
+                    (5, bytes_field(1, b"x"), "childValue"),
+                    (6, bytes_field(1, b"x"), "manyChildren"),
+                ] {
+                    let bytes = [valid.clone(), bytes_field(number, &payload)].concat();
+                    assert_failure(
+                        Names::decode_from_slice(&bytes).unwrap().validate(),
+                        "string.min_len",
+                        Some(field),
+                    );
+                    assert_failure(
+                        NamesView::decode_view(&bytes).unwrap().validate(),
+                        "string.min_len",
+                        Some(field),
+                    );
+                }
+            }
+
+            #[test]
+            fn cel_uses_proto_names_and_resolved_rust_accessors() {
+                for (number, payload, rule, field) in [
+                    (1, b"blocked".to_vec(), "names.cel", None),
+                    (2, b"blocked".to_vec(), "names.cel", None),
+                    (
+                        5,
+                        bytes_field(1, b"blocked"),
+                        "child.cel",
+                        Some("childValue"),
+                    ),
+                    (
+                        6,
+                        bytes_field(1, b"blocked"),
+                        "children.cel",
+                        Some("manyChildren"),
+                    ),
+                    (7, b"blocked".to_vec(), "acronym.cel", Some("XML2Request")),
+                    (
+                        8,
+                        b"blocked".to_vec(),
+                        "underscore.cel",
+                        Some("_leadingName_"),
+                    ),
+                    (9, b"blocked".to_vec(), "keyword.cel", Some("Type")),
+                    (10, b"blocked".to_vec(), "self.cel", Some("Self")),
+                ] {
+                    let bytes = [bytes_field(1, b"ok"), bytes_field(number, &payload)].concat();
+                    assert_failure(
+                        Names::decode_from_slice(&bytes).unwrap().validate(),
+                        rule,
+                        field,
+                    );
+                    assert_failure(
+                        NamesView::decode_view(&bytes).unwrap().validate(),
+                        rule,
+                        field,
+                    );
+                }
+            }
+
+            #[test]
+            fn oneof_accessors_preserve_enum_variants_and_presence() {
+                let valid = bytes_field(1, b"ok");
+                assert!(
+                    Choices::decode_from_slice(&valid)
+                        .unwrap()
+                        .validate()
+                        .is_ok()
+                );
+                assert!(ChoicesView::decode_view(&valid).unwrap().validate().is_ok());
+                for (bytes, rule, field) in [
+                    (vec![], "required", Some("choiceValue")),
+                    (bytes_field(1, b"x"), "string.min_len", Some("textValue")),
+                    (vec![0x10, 1], "choice.cel", None),
+                    (
+                        [valid, bytes_field(3, b"ok")].concat(),
+                        "message.oneof",
+                        None,
+                    ),
+                ] {
+                    assert_failure(
+                        Choices::decode_from_slice(&bytes).unwrap().validate(),
+                        rule,
+                        field,
+                    );
+                    assert_failure(
+                        ChoicesView::decode_view(&bytes).unwrap().validate(),
+                        rule,
+                        field,
+                    );
+                }
+            }
+
+            #[test]
+            fn collisions_fallback_and_inherited_adjustments_validate() {
+                let valid = [
+                    bytes_field(1, b"ok"),
+                    bytes_field(2, b""),
+                    bytes_field(3, b""),
+                    bytes_field(4, b"ok"),
+                ]
+                .concat();
+                assert!(
+                    Collision::decode_from_slice(&valid)
+                        .unwrap()
+                        .validate()
+                        .is_ok()
+                );
+                assert!(
+                    CollisionView::decode_view(&valid)
+                        .unwrap()
+                        .validate()
+                        .is_ok()
+                );
+                for (number, value, rule, field) in [
+                    (1, b"x".as_slice(), "string.min_len", "userName"),
+                    (1, b"blocked".as_slice(), "collision.cel", ""),
+                    (4, b"x".as_slice(), "string.min_len", "textValue"),
+                ] {
+                    let bytes = [valid.clone(), bytes_field(number, value)].concat();
+                    let field = if field.is_empty() { None } else { Some(field) };
+                    assert_failure(
+                        Collision::decode_from_slice(&bytes).unwrap().validate(),
+                        rule,
+                        field,
+                    );
+                    assert_failure(
+                        CollisionView::decode_view(&bytes).unwrap().validate(),
+                        rule,
+                        field,
+                    );
+                }
+                let fallback = [
+                    bytes_field(11, b"ok"),
+                    bytes_field(12, b""),
+                    bytes_field(13, b""),
+                    bytes_field(14, b"ok"),
+                ]
+                .concat();
+                assert!(
+                    Fallback::decode_from_slice(&fallback)
+                        .unwrap()
+                        .validate()
+                        .is_ok()
+                );
+                assert!(
+                    FallbackView::decode_view(&fallback)
+                        .unwrap()
+                        .validate()
+                        .is_ok()
+                );
+                for (number, field) in [(11, "otherName"), (14, "unrelatedName")] {
+                    let bytes = [fallback.clone(), bytes_field(number, b"x")].concat();
+                    assert_failure(
+                        Fallback::decode_from_slice(&bytes).unwrap().validate(),
+                        "string.min_len",
+                        Some(field),
+                    );
+                    assert_failure(
+                        FallbackView::decode_view(&bytes).unwrap().validate(),
+                        "string.min_len",
+                        Some(field),
+                    );
+                }
+                let inherited = [bytes_field(1, b"ok"), bytes_field(11, b"ok")].concat();
+                assert!(
+                    Inherited::decode_from_slice(&inherited)
+                        .unwrap()
+                        .validate()
+                        .is_ok()
+                );
+                assert!(
+                    InheritedView::decode_view(&inherited)
+                        .unwrap()
+                        .validate()
+                        .is_ok()
+                );
+                for (number, field) in [(1, "userName"), (11, "otherName")] {
+                    let bytes = [inherited.clone(), bytes_field(number, b"x")].concat();
+                    assert_failure(
+                        Inherited::decode_from_slice(&bytes).unwrap().validate(),
+                        "string.min_len",
+                        Some(field),
+                    );
+                    assert_failure(
+                        InheritedView::decode_view(&bytes).unwrap().validate(),
+                        "string.min_len",
+                        Some(field),
+                    );
+                }
+            }
+        }
+    };
+}
+
+mod checks {
+    naming_tests!(verbatim);
+    naming_tests!(idiomatic);
+}


### PR DESCRIPTION
Validators now support buffa's `idiomatic_field_names` option. With the option enabled, a protobuf field such as `userName` is accessed through the Rust name buffa generates, including numbered suffixes and verbatim fallbacks when names collide. CEL field lookups and validation errors retain the protobuf spelling.

The scanner plans names across all request descriptors, including imports and nested messages. Owned and borrowed-view validation use those resolved accessors for fields, collections, message-level oneofs, and CEL schemas; oneof enum and variant names retain buffa's existing spelling. The bare flag, explicit true/false values, and invalid-value errors are covered through the plugin executable.

In-process consumers that construct `FieldValidator` or `OneofValidator` literals must supply the new `rust_name` field. Consumers calling `scan::gather` receive the resolved name automatically. This warrants a minor version bump for the pre-1.0 generator crate.

Validation: `cargo build --locked --workspace`; `cargo test --locked --workspace --all-features --all-targets` (242 passed); `cargo test --locked --workspace --doc`; `hk check --all --slow` (including Clippy, dependency audit, formatting, and secret scans); and package-content verification. Regression tests compare naming with buffa and compile both generators together in both naming modes, exercising owned and borrowed validation and original field paths.

Implements https://github.com/mathematic-inc/protovalidate-buffa/discussions/53. Thanks to @marcusklaas for the proposal and explanation of the fork's requirements.
