### PR TITLE
feat(codegen)!: add independent packaging and file grouping options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "protovalidate-buffa-packaging-examples"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "buffa",
+ "buffa-codegen",
+ "protoc-gen-protovalidate-buffa",
+ "protovalidate-buffa",
+]
+
+[[package]]
 name = "protovalidate-buffa-protos"
 version = "0.7.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/protovalidate-buffa-conformance",
   "crates/protovalidate-buffa-macros",
   "crates/protovalidate-buffa-protos",
+  "examples/packaging",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -154,6 +154,66 @@ For in-process generation, set `CodeGeneratorRequest.parameter` before calling
 `scan::gather`, for example `Some("idiomatic_field_names=true".into())`. Then pass
 the scanned validators to `emit::render` or `emit::render_with_options` as usual.
 
+### Include validators beside message types
+
+Set `packaging=false` to generate one `<package>.validate.rs` per declared
+protobuf package. Include that file in the same Rust module as its Buffa types.
+The plugin emits no `mod.rs` or `<package>.mod.rs` in this mode, so it can share
+an output directory with your handwritten module files.
+
+```yaml
+- local: protoc-gen-buffa
+  out: gen/proto
+  strategy: all
+  opt: [file_per_package=true]
+- local: protoc-gen-protovalidate-buffa
+  out: gen/proto
+  strategy: all
+  opt: [packaging=false]
+```
+
+For package `example.v1`, mount both generated files:
+
+```rust
+pub mod example {
+    pub mod v1 {
+        use crate::example;
+
+        include!("gen/proto/example.v1.rs");
+        include!("gen/proto/example.v1.validate.rs");
+    }
+}
+```
+
+The filename follows the declared package, even when the source directories
+differ. Multiple `.proto` files in a package share one validator file; keep
+`strategy: all` so each plugin sees them together. Packages with messages but
+no validation annotations still get validators. Packages with only enums or
+services need no validator include. The unnamed package uses
+`__buffa.validate.rs`, beside Buffa's `__buffa.rs`.
+
+Preserve the package hierarchy for cross-package references. Enum validators
+use paths beginning at the top-level protobuf package, so bring those roots
+into scope in each consuming module (for example, `use crate::example;`).
+
+`proto_module` is ignored with `packaging=false`. The default,
+`packaging=true`, and the bare `packaging` flag preserve the existing output:
+one validator file per source proto, plus the generated module tree. Other
+`packaging` values fail generation with an error. When switching an existing
+output directory to this mode, remove old generated packaging files once;
+generation does not delete files left by previous runs.
+
+For in-process generation, pass
+`emit::Options { packaging: false, ..Default::default() }` to
+`emit::render_with_options`. Code that previously constructed `Options` with
+only `proto_module` must add `..Default::default()` or set `packaging` explicitly.
+
+Two [runnable examples](examples/packaging/) demonstrate a single package and
+a package split across source files with an enum from another package. Both
+exercise validation on owned messages and borrowed views.
+
+### Annotate and validate a request
+
 Annotate a proto (see upstream for the full rule vocabulary):
 
 ```protobuf

--- a/README.md
+++ b/README.md
@@ -156,10 +156,22 @@ the scanned validators to `emit::render` or `emit::render_with_options` as usual
 
 ### Include validators beside message types
 
-Set `packaging=false` to generate one `<package>.validate.rs` per declared
-protobuf package. Include that file in the same Rust module as its Buffa types.
-The plugin emits no `mod.rs` or `<package>.mod.rs` in this mode, so it can share
-an output directory with your handwritten module files.
+Two independent flags control the output:
+
+- `packaging=false` omits `mod.rs` and `<package>.mod.rs` and adds a `.validate`
+  infix to validator filenames. This lets you share an output directory with
+  handwritten module files. The default is `true`.
+- `file_per_package=true` merges validators by declared protobuf package.
+  The default is `false`, which emits one file per source proto.
+
+| `packaging` | `file_per_package` | Validator files | Module files |
+| --- | --- | --- | --- |
+| `true` | `false` | `<source>.rs` | Yes (default layout) |
+| `false` | `false` | `<source>.validate.rs` | No |
+| `true` | `true` | `<package>.rs` | Yes |
+| `false` | `true` | `<package>.validate.rs` | No |
+
+To mount one validator file beside each package's Buffa types, set both flags:
 
 ```yaml
 - local: protoc-gen-buffa
@@ -169,7 +181,7 @@ an output directory with your handwritten module files.
 - local: protoc-gen-protovalidate-buffa
   out: gen/proto
   strategy: all
-  opt: [packaging=false]
+  opt: [packaging=false, file_per_package=true]
 ```
 
 For package `example.v1`, mount both generated files:
@@ -185,8 +197,9 @@ pub mod example {
 }
 ```
 
-The filename follows the declared package, even when the source directories
-differ. Multiple `.proto` files in a package share one validator file; keep
+With `file_per_package=true`, the filename follows the declared package, even
+when the source directories differ. Multiple `.proto` files in a package share
+one validator file; keep
 `strategy: all` so each plugin sees them together. Packages with messages but
 no validation annotations still get validators. Packages with only enums or
 services need no validator include. The unnamed package uses
@@ -196,20 +209,28 @@ Preserve the package hierarchy for cross-package references. Enum validators
 use paths beginning at the top-level protobuf package, so bring those roots
 into scope in each consuming module (for example, `use crate::example;`).
 
-`proto_module` is ignored with `packaging=false`. The default,
-`packaging=true`, and the bare `packaging` flag preserve the existing output:
-one validator file per source proto, plus the generated module tree. Other
-`packaging` values fail generation with an error. When switching an existing
+`proto_module` is ignored with `packaging=false`. Omitting both flags preserves
+the existing output. Either bare flag means `true`; both accept explicit
+`true` and `false`, and other values fail generation with an error.
+When switching an existing
 output directory to this mode, remove old generated packaging files once;
 generation does not delete files left by previous runs.
 
-For in-process generation, pass
-`emit::Options { packaging: false, ..Default::default() }` to
-`emit::render_with_options`. Code that previously constructed `Options` with
-only `proto_module` must add `..Default::default()` or set `packaging` explicitly.
+For in-process generation, pass these options to `emit::render_with_options`:
 
-Two [runnable examples](examples/packaging/) demonstrate a single package and
-a package split across source files with an enum from another package. Both
+```rust
+emit::Options {
+    packaging: false,
+    file_per_package: true,
+    ..Default::default()
+}
+```
+
+Code that previously constructed `Options` with only `proto_module` must add
+`..Default::default()` or set both new fields explicitly.
+
+Two [runnable examples](examples/packaging/) demonstrate per-source output and
+per-package output with an enum from another package. Both
 exercise validation on owned messages and borrowed views.
 
 ### Annotate and validate a request

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
@@ -1,5 +1,5 @@
 //! Orchestrate the emit phase: group scanned validators by source `.proto`
-//! file with module packaging, or by package for inclusion beside message types.
+//! file or package, with optional module packaging.
 
 use anyhow::Result;
 use buffa_codegen::generated::compiler::code_generator_response::File;
@@ -15,7 +15,11 @@ use crate::scan::MessageValidators;
 /// ```
 /// use protoc_gen_protovalidate_buffa::emit::{self, Options};
 ///
-/// let options = Options { packaging: false, ..Options::default() };
+/// let options = Options {
+///     packaging: false,
+///     file_per_package: true,
+///     ..Options::default()
+/// };
 /// let files = emit::render_with_options(&[], &options)?;
 /// assert!(files.is_empty());
 /// # Ok::<(), anyhow::Error>(())
@@ -27,11 +31,15 @@ pub struct Options {
     /// inside each leaf package so local and cross-package type names resolve.
     /// Ignored when [`Self::packaging`] is `false`.
     pub proto_module: String,
-    /// Emit a module tree and one validator file per source proto (default: `true`).
-    /// Set to `false` to emit only `<package>.validate.rs`, with all validators
-    /// in that package, for inclusion in the same module as the message types.
-    /// The unnamed package uses Buffa's filename stem: `__buffa.validate.rs`.
+    /// Emit the `mod.rs` and `<package>.mod.rs` module files (default: `true`).
+    /// Set to `false` to emit only validators with a `.validate.rs` suffix,
+    /// for inclusion in the same module as the message types.
     pub packaging: bool,
+    /// Merge validators by declared protobuf package (default: `false`).
+    /// When `false`, emit one validator file per source proto. When `true`,
+    /// use the package name as the filename stem, or `__buffa` for the unnamed
+    /// package, matching Buffa. Independent of [`Self::packaging`].
+    pub file_per_package: bool,
 }
 
 impl Default for Options {
@@ -39,6 +47,7 @@ impl Default for Options {
         Self {
             proto_module: "crate::proto".to_string(),
             packaging: true,
+            file_per_package: false,
         }
     }
 }
@@ -146,9 +155,11 @@ pub fn render(messages: &[MessageValidators]) -> Result<Vec<File>> {
 /// Removes the need for an external "generate mod tree" script in
 /// projects that consume this plugin.
 ///
-/// With [`Options::packaging`] set to `false`, emits one `<package>.validate.rs`
-/// per declared protobuf package and no module files. Include each validator
-/// file beside the corresponding Buffa types. `proto_module` is ignored.
+/// [`Options::file_per_package`] independently groups validators by declared
+/// protobuf package instead of source file. With [`Options::packaging`] set
+/// to `false`, emits no module files, adds `.validate` before the `.rs` suffix,
+/// and ignores `proto_module`. Set `packaging=false,file_per_package=true` for one
+/// `<package>.validate.rs` per package beside the corresponding Buffa types.
 ///
 /// # Errors
 ///
@@ -157,32 +168,14 @@ pub fn render_with_options(messages: &[MessageValidators], opts: &Options) -> Re
     use std::collections::BTreeMap;
 
     let schemas = cel::build_schema_index(messages);
-    if !opts.packaging {
-        let mut by_package: BTreeMap<&str, Vec<&MessageValidators>> = BTreeMap::new();
-        for message in messages {
-            by_package
-                .entry(&message.package)
-                .or_default()
-                .push(message);
-        }
-        return by_package
-            .into_iter()
-            .map(|(package, messages)| {
-                let filename = buffa_codegen::package_to_filename(package);
-                let stem = filename.strip_suffix(".rs").unwrap_or(&filename);
-                let path = format!("{stem}.validate.rs");
-                let body = render_file(&messages, &schemas)?;
-                Ok(File {
-                    content: Some(format_token_stream(&body, "", &path)?),
-                    name: Some(path),
-                    ..Default::default()
-                })
-            })
-            .collect();
-    }
-    let mut by_file: BTreeMap<String, Vec<&MessageValidators>> = BTreeMap::new();
+    let mut groups: BTreeMap<&str, Vec<&MessageValidators>> = BTreeMap::new();
     for m in messages {
-        by_file.entry(m.source_file.clone()).or_default().push(m);
+        let key = if opts.file_per_package {
+            &m.package
+        } else {
+            &m.source_file
+        };
+        groups.entry(key).or_default().push(m);
     }
 
     let mut files = Vec::new();
@@ -190,19 +183,35 @@ pub fn render_with_options(messages: &[MessageValidators], opts: &Options) -> Re
     // filenames, so the packaging file can `include!()` each per-package
     // file under the right `pub mod` nesting.
     let mut by_package: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for (source_file, msgs) in by_file {
+    for (key, msgs) in groups {
         let body = render_file(&msgs, &schemas)?;
-        let stem = source_file.trim_end_matches(".proto").replace('/', ".");
-        let path = format!("{stem}.rs");
+        let stem = if opts.file_per_package {
+            let filename = buffa_codegen::package_to_filename(key);
+            filename
+                .strip_suffix(".rs")
+                .unwrap_or(&filename)
+                .to_string()
+        } else {
+            key.trim_end_matches(".proto").replace('/', ".")
+        };
+        let path = if opts.packaging {
+            format!("{stem}.rs")
+        } else {
+            format!("{stem}.validate.rs")
+        };
         let body_str = body.to_string();
         let parsed = syn::parse2(body.clone()).map_err(|e| {
-            anyhow::anyhow!("syn parse failed for {source_file}: {e}\n--- BEGIN TOKENS ---\n{body_str}\n--- END TOKENS ---")
+            anyhow::anyhow!("syn parse failed for {key}: {e}\n--- BEGIN TOKENS ---\n{body_str}\n--- END TOKENS ---")
         })?;
         // The package is everything before the trailing file stem in the
         // dotted form ("example.v1alpha1.style" → package "example.v1alpha1").
-        let package = match stem.rsplit_once('.') {
-            Some((p, _)) => p.to_string(),
-            None => stem.clone(),
+        let package = if opts.file_per_package {
+            key.to_string()
+        } else {
+            match stem.rsplit_once('.') {
+                Some((p, _)) => p.to_string(),
+                None => stem.clone(),
+            }
         };
         by_package.entry(package).or_default().push(path.clone());
         files.push(File {
@@ -212,6 +221,10 @@ pub fn render_with_options(messages: &[MessageValidators], opts: &Options) -> Re
             generated_code_info: None.into(),
             ..Default::default()
         });
+    }
+
+    if !opts.packaging {
+        return Ok(files);
     }
 
     // For each leaf package, emit a `<pkg>.mod.rs` that flat-includes
@@ -229,14 +242,14 @@ pub fn render_with_options(messages: &[MessageValidators], opts: &Options) -> Re
         let body = quote! {
             #( #includes )*
         };
-        let label = format!("{package}.mod.rs");
+        let label = buffa_codegen::package_to_mod_filename(package);
         let formatted = format_token_stream(
             &body,
             "// @generated by protoc-gen-protovalidate-buffa. DO NOT EDIT.\n",
             &label,
         )?;
         files.push(File {
-            name: Some(format!("{package}.mod.rs")),
+            name: Some(label),
             content: Some(formatted),
             insertion_point: None,
             generated_code_info: None.into(),
@@ -303,7 +316,7 @@ fn render_mod_rs(
     let mut root = PackageNode::default();
     for package in by_package.keys() {
         let mut cur = &mut root;
-        for seg in package.split('.') {
+        for seg in package.split('.').filter(|seg| !seg.is_empty()) {
             cur = cur.children.entry(seg.to_string()).or_default();
         }
         cur.package = Some(package.clone());
@@ -346,10 +359,15 @@ fn render_package_node(
             .iter()
             .map(|s| quote::format_ident!("{}", s))
             .collect();
-        let pkg_mod = format!("{pkg}.mod.rs");
+        let pkg_mod = buffa_codegen::package_to_mod_filename(pkg);
         let pkg_lit = proc_macro2::Literal::string(&pkg_mod);
+        let import = if segs.is_empty() {
+            quote! { pub(crate) use #proto_module ::*; }
+        } else {
+            quote! { pub(crate) use #proto_module :: #( #segs )::* ::*; }
+        };
         quote! {
-            pub(crate) use #proto_module :: #( #segs )::* ::*;
+            #import
             include!(#pkg_lit);
         }
     });

--- a/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/emit/mod.rs
@@ -1,5 +1,5 @@
 //! Orchestrate the emit phase: group scanned validators by source `.proto`
-//! file and render one Rust file per source.
+//! file with module packaging, or by package for inclusion beside message types.
 
 use anyhow::Result;
 use buffa_codegen::generated::compiler::code_generator_response::File;
@@ -9,18 +9,36 @@ use quote::quote;
 use crate::scan::MessageValidators;
 
 /// Plugin options parsed from `opt:` in `buf.gen.yaml`.
+///
+/// # Examples
+///
+/// ```
+/// use protoc_gen_protovalidate_buffa::emit::{self, Options};
+///
+/// let options = Options { packaging: false, ..Options::default() };
+/// let files = emit::render_with_options(&[], &options)?;
+/// assert!(files.is_empty());
+/// # Ok::<(), anyhow::Error>(())
+/// ```
 #[derive(Debug, Clone)]
 pub struct Options {
     /// Rust module path under which the protobuf message types live —
     /// the `mod.rs` packaging file emits `pub(crate) use <proto_module>::<pkg>::*;`
     /// inside each leaf package so local and cross-package type names resolve.
+    /// Ignored when [`Self::packaging`] is `false`.
     pub proto_module: String,
+    /// Emit a module tree and one validator file per source proto (default: `true`).
+    /// Set to `false` to emit only `<package>.validate.rs`, with all validators
+    /// in that package, for inclusion in the same module as the message types.
+    /// The unnamed package uses Buffa's filename stem: `__buffa.validate.rs`.
+    pub packaging: bool,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
             proto_module: "crate::proto".to_string(),
+            packaging: true,
         }
     }
 }
@@ -122,11 +140,15 @@ pub fn render(messages: &[MessageValidators]) -> Result<Vec<File>> {
 
 /// Same as [`render`] but threads parsed plugin options through.
 ///
-/// Also emits a `mod.rs` packaging file that mirrors the proto-package
+/// By default, also emits a `mod.rs` packaging file that mirrors the proto-package
 /// hierarchy as nested `pub mod` declarations, and per-package
 /// `<pkg>.mod.rs` files that flat-`include!()` each per-source output.
 /// Removes the need for an external "generate mod tree" script in
 /// projects that consume this plugin.
+///
+/// With [`Options::packaging`] set to `false`, emits one `<package>.validate.rs`
+/// per declared protobuf package and no module files. Include each validator
+/// file beside the corresponding Buffa types. `proto_module` is ignored.
 ///
 /// # Errors
 ///
@@ -135,6 +157,29 @@ pub fn render_with_options(messages: &[MessageValidators], opts: &Options) -> Re
     use std::collections::BTreeMap;
 
     let schemas = cel::build_schema_index(messages);
+    if !opts.packaging {
+        let mut by_package: BTreeMap<&str, Vec<&MessageValidators>> = BTreeMap::new();
+        for message in messages {
+            by_package
+                .entry(&message.package)
+                .or_default()
+                .push(message);
+        }
+        return by_package
+            .into_iter()
+            .map(|(package, messages)| {
+                let filename = buffa_codegen::package_to_filename(package);
+                let stem = filename.strip_suffix(".rs").unwrap_or(&filename);
+                let path = format!("{stem}.validate.rs");
+                let body = render_file(&messages, &schemas)?;
+                Ok(File {
+                    content: Some(format_token_stream(&body, "", &path)?),
+                    name: Some(path),
+                    ..Default::default()
+                })
+            })
+            .collect();
+    }
     let mut by_file: BTreeMap<String, Vec<&MessageValidators>> = BTreeMap::new();
     for m in messages {
         by_file.entry(m.source_file.clone()).or_default().push(m);

--- a/crates/protoc-gen-protovalidate-buffa/src/main.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/main.rs
@@ -60,12 +60,16 @@ fn parse_opts(parameter: &str) -> anyhow::Result<emit::Options> {
             "proto_module" if part.contains('=') => {
                 opts.proto_module = value.trim().to_string();
             }
-            "packaging" => {
-                opts.packaging = match value.trim() {
+            key @ ("packaging" | "file_per_package") => {
+                let enabled = match value.trim() {
                     "true" => true,
                     "false" => false,
-                    value => anyhow::bail!("packaging must be true or false, got {value:?}"),
+                    value => anyhow::bail!("{key} must be true or false, got {value:?}"),
                 };
+                match key {
+                    "packaging" => opts.packaging = enabled,
+                    _ => opts.file_per_package = enabled,
+                }
             }
             _ => {}
         }

--- a/crates/protoc-gen-protovalidate-buffa/src/main.rs
+++ b/crates/protoc-gen-protovalidate-buffa/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
 fn run(
     request: &CodeGeneratorRequest,
 ) -> anyhow::Result<Vec<buffa_codegen::generated::compiler::code_generator_response::File>> {
-    let opts = parse_opts(request.parameter.as_deref().unwrap_or(""));
+    let opts = parse_opts(request.parameter.as_deref().unwrap_or(""))?;
     let validators = scan::gather(request)?;
     emit::render_with_options(&validators, &opts)
 }
@@ -48,18 +48,27 @@ fn run(
 /// comma-separated `key=value,flag,...` list (the format protoc / buf use
 /// to invoke plugins). Unknown keys are ignored so callers can pass
 /// forward-compatible options.
-fn parse_opts(parameter: &str) -> emit::Options {
+fn parse_opts(parameter: &str) -> anyhow::Result<emit::Options> {
     let mut opts = emit::Options::default();
     for part in parameter.split(',') {
         let part = part.trim();
         if part.is_empty() {
             continue;
         }
-        if let Some((k, v)) = part.split_once('=')
-            && k.trim() == "proto_module"
-        {
-            opts.proto_module = v.trim().to_string();
+        let (key, value) = part.split_once('=').unwrap_or((part, "true"));
+        match key.trim() {
+            "proto_module" if part.contains('=') => {
+                opts.proto_module = value.trim().to_string();
+            }
+            "packaging" => {
+                opts.packaging = match value.trim() {
+                    "true" => true,
+                    "false" => false,
+                    value => anyhow::bail!("packaging must be true or false, got {value:?}"),
+                };
+            }
+            _ => {}
         }
     }
-    opts
+    Ok(opts)
 }

--- a/crates/protoc-gen-protovalidate-buffa/tests/emit_packaging.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/emit_packaging.rs
@@ -1,0 +1,218 @@
+//! Discussion #58: opt out of packaging without overwriting a consumer's modules.
+#![warn(rust_2018_idioms)]
+
+use std::{
+    io::Write as _,
+    process::{Command, Stdio},
+};
+
+use buffa::Message as _;
+use buffa_codegen::generated::{
+    compiler::{CodeGeneratorRequest, CodeGeneratorResponse},
+    descriptor::{DescriptorProto, FileDescriptorProto},
+};
+use protoc_gen_protovalidate_buffa::{emit, scan};
+
+fn request() -> CodeGeneratorRequest {
+    // Neither the directory nor the filename implies the declared package.
+    let sources = [
+        ("elsewhere/first.proto", "example.v1", "First"),
+        ("second.proto", "example.v1", "Second"),
+        ("elsewhere/third.proto", "other.v1", "Third"),
+    ];
+    CodeGeneratorRequest {
+        file_to_generate: sources.iter().map(|(file, _, _)| (*file).into()).collect(),
+        proto_file: sources
+            .iter()
+            .map(|(file, package, name)| FileDescriptorProto {
+                name: Some((*file).into()),
+                package: Some((*package).into()),
+                syntax: Some("proto3".into()),
+                message_type: vec![DescriptorProto {
+                    name: Some((*name).into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            })
+            .collect(),
+        parameter: Some("packaging=false".into()),
+        ..Default::default()
+    }
+}
+
+fn invoke_plugin(request: &CodeGeneratorRequest) -> CodeGeneratorResponse {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_protoc-gen-protovalidate-buffa"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start plugin");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(&request.encode_to_vec())
+        .expect("write request");
+    let output = child.wait_with_output().expect("read plugin output");
+    assert!(output.status.success(), "{:?}", output.stderr);
+    CodeGeneratorResponse::decode_from_slice(&output.stdout).expect("decode response")
+}
+
+#[test]
+fn flat_output_merges_declared_packages_and_includes_owned_and_view_impls() {
+    let request = request();
+    let response = invoke_plugin(&request);
+    assert!(response.error.is_none(), "{:?}", response.error);
+    let names: Vec<_> = response
+        .file
+        .iter()
+        .map(|f| f.name.as_deref().unwrap())
+        .collect();
+    assert_eq!(names, ["example.v1.validate.rs", "other.v1.validate.rs"]);
+    for (file, types) in response
+        .file
+        .iter()
+        .zip([&["First", "Second"][..], &["Third"]])
+    {
+        let content = file.content.as_deref().unwrap();
+        syn::parse_file(content).expect("valid Rust syntax");
+        assert_eq!(content.matches("use super::*;").count(), 1);
+        for name in types {
+            assert!(content.contains(&format!("Validate for {name}")));
+            assert!(content.contains(&format!("__buffa::view::{name}View<'_>")));
+        }
+    }
+    let scanned = scan::gather(&request).unwrap();
+    let options = emit::Options {
+        packaging: false,
+        ..Default::default()
+    };
+    assert_eq!(
+        response.file,
+        emit::render_with_options(&scanned, &options).unwrap()
+    );
+    assert_eq!(response.supported_features, Some(1 | 2));
+    assert!(response.minimum_edition.is_some());
+    assert!(response.maximum_edition.is_some());
+}
+
+#[test]
+fn default_true_and_bare_flag_preserve_packaged_output() {
+    let mut request = request();
+    let expected = emit::render(&scan::gather(&request).unwrap()).unwrap();
+    let names: Vec<_> = expected
+        .iter()
+        .map(|f| f.name.as_deref().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "elsewhere.first.rs",
+            "elsewhere.third.rs",
+            "second.rs",
+            "elsewhere.mod.rs",
+            "second.mod.rs",
+            "mod.rs",
+        ]
+    );
+    for parameter in [
+        "",
+        "packaging=true",
+        "packaging",
+        "packaging=false,packaging=true",
+    ] {
+        request.parameter = Some(parameter.into());
+        let response = invoke_plugin(&request);
+        assert!(
+            response.error.is_none(),
+            "{parameter}: {:?}",
+            response.error
+        );
+        assert_eq!(response.file, expected, "{parameter}");
+    }
+}
+
+#[test]
+fn flat_output_ignores_proto_module_even_when_it_is_invalid() {
+    let mut request = request();
+    let expected = invoke_plugin(&request).file;
+    request.parameter =
+        Some(" proto_module = not a Rust path, packaging = false, unknown=1, ".into());
+    let response = invoke_plugin(&request);
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(response.file, expected);
+    let options = emit::Options {
+        proto_module: "not a Rust path".into(),
+        packaging: false,
+    };
+    assert_eq!(
+        emit::render_with_options(&scan::gather(&request).unwrap(), &options).unwrap(),
+        expected
+    );
+}
+
+#[test]
+fn invalid_packaging_returns_error_without_files() {
+    let mut request = request();
+    for parameter in [
+        "packaging=",
+        "packaging=no",
+        "packaging=0",
+        "packaging=FALSE",
+        "packaging=false,packaging=oops",
+    ] {
+        request.parameter = Some(parameter.into());
+        let response = invoke_plugin(&request);
+        assert!(
+            response
+                .error
+                .unwrap()
+                .contains("packaging must be true or false"),
+            "{parameter}"
+        );
+        assert!(response.file.is_empty(), "{parameter}");
+    }
+}
+
+#[test]
+fn unnamed_package_and_rs_suffix_follow_buffa_filenames() {
+    let mut request = request();
+    request.proto_file[0].package = None;
+    request.proto_file[1].package = Some(String::new());
+    request.proto_file[2].package = Some("other.rs".into());
+    let response = invoke_plugin(&request);
+    assert!(response.error.is_none(), "{:?}", response.error);
+    let names: Vec<_> = response
+        .file
+        .iter()
+        .map(|f| f.name.as_deref().unwrap())
+        .collect();
+    assert_eq!(names, ["__buffa.validate.rs", "other.rs.validate.rs"]);
+    let unnamed = response.file[0].content.as_deref().unwrap();
+    assert!(unnamed.contains("Validate for First"));
+    assert!(unnamed.contains("Validate for Second"));
+}
+
+#[test]
+fn empty_generation_emits_no_files_in_flat_mode() {
+    let mut request = request();
+    request.file_to_generate.clear();
+    let response = invoke_plugin(&request);
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert!(response.file.is_empty());
+}
+
+#[test]
+fn imported_messages_are_not_emitted() {
+    let mut request = request();
+    request.file_to_generate = vec!["second.proto".into()];
+    let response = invoke_plugin(&request);
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(response.file.len(), 1);
+    let file = &response.file[0];
+    assert_eq!(file.name.as_deref(), Some("example.v1.validate.rs"));
+    let content = file.content.as_deref().unwrap();
+    assert!(content.contains("Validate for Second"));
+    assert!(!content.contains("Validate for First"));
+    assert!(!content.contains("Validate for Third"));
+}

--- a/crates/protoc-gen-protovalidate-buffa/tests/emit_packaging.rs
+++ b/crates/protoc-gen-protovalidate-buffa/tests/emit_packaging.rs
@@ -35,7 +35,7 @@ fn request() -> CodeGeneratorRequest {
                 ..Default::default()
             })
             .collect(),
-        parameter: Some("packaging=false".into()),
+        parameter: Some("packaging=false,file_per_package=true".into()),
         ..Default::default()
     }
 }
@@ -85,6 +85,7 @@ fn flat_output_merges_declared_packages_and_includes_owned_and_view_impls() {
     let scanned = scan::gather(&request).unwrap();
     let options = emit::Options {
         packaging: false,
+        file_per_package: true,
         ..Default::default()
     };
     assert_eq!(
@@ -136,14 +137,17 @@ fn default_true_and_bare_flag_preserve_packaged_output() {
 fn flat_output_ignores_proto_module_even_when_it_is_invalid() {
     let mut request = request();
     let expected = invoke_plugin(&request).file;
-    request.parameter =
-        Some(" proto_module = not a Rust path, packaging = false, unknown=1, ".into());
+    request.parameter = Some(
+        " proto_module = not a Rust path, packaging = false, file_per_package = true, unknown=1, "
+            .into(),
+    );
     let response = invoke_plugin(&request);
     assert!(response.error.is_none(), "{:?}", response.error);
     assert_eq!(response.file, expected);
     let options = emit::Options {
         proto_module: "not a Rust path".into(),
         packaging: false,
+        file_per_package: true,
     };
     assert_eq!(
         emit::render_with_options(&scan::gather(&request).unwrap(), &options).unwrap(),
@@ -215,4 +219,127 @@ fn imported_messages_are_not_emitted() {
     assert!(content.contains("Validate for Second"));
     assert!(!content.contains("Validate for First"));
     assert!(!content.contains("Validate for Third"));
+}
+
+#[test]
+fn packaging_and_file_per_package_are_independent() {
+    let mut request = request();
+    for (parameter, expected_names) in [
+        (
+            "packaging=false,file_per_package=false",
+            vec![
+                "elsewhere.first.validate.rs",
+                "elsewhere.third.validate.rs",
+                "second.validate.rs",
+            ],
+        ),
+        (
+            "packaging=true,file_per_package=true",
+            vec![
+                "example.v1.rs",
+                "other.v1.rs",
+                "example.v1.mod.rs",
+                "other.v1.mod.rs",
+                "mod.rs",
+            ],
+        ),
+    ] {
+        request.parameter = Some(parameter.into());
+        let response = invoke_plugin(&request);
+        assert!(
+            response.error.is_none(),
+            "{parameter}: {:?}",
+            response.error
+        );
+        let names: Vec<_> = response
+            .file
+            .iter()
+            .map(|f| f.name.as_deref().unwrap())
+            .collect();
+        assert_eq!(names, expected_names, "{parameter}");
+        for file in &response.file {
+            syn::parse_file(file.content.as_deref().unwrap()).expect("valid Rust syntax");
+        }
+        if parameter == "packaging=true,file_per_package=true" {
+            let package = response.file[0].content.as_deref().unwrap();
+            assert!(package.contains("Validate for First"));
+            assert!(package.contains("Validate for Second"));
+            assert!(
+                response.file[2]
+                    .content
+                    .as_deref()
+                    .unwrap()
+                    .contains("include!(\"example.v1.rs\");")
+            );
+            assert!(
+                response.file[4]
+                    .content
+                    .as_deref()
+                    .unwrap()
+                    .contains("crate::proto::example::v1::*")
+            );
+        }
+    }
+}
+
+#[test]
+fn file_per_package_defaults_to_false_and_accepts_bare_flag() {
+    let mut request = request();
+    request.parameter = Some("packaging=false,file_per_package=false".into());
+    let expected_per_source = invoke_plugin(&request).file;
+    request.parameter = Some("packaging=false,file_per_package=true".into());
+    let expected_per_package = invoke_plugin(&request).file;
+    for (parameter, expected) in [
+        ("packaging=false", &expected_per_source),
+        (
+            "packaging=false,file_per_package=true,file_per_package=false",
+            &expected_per_source,
+        ),
+        ("packaging=false,file_per_package", &expected_per_package),
+    ] {
+        request.parameter = Some(parameter.into());
+        let response = invoke_plugin(&request);
+        assert!(
+            response.error.is_none(),
+            "{parameter}: {:?}",
+            response.error
+        );
+        assert_eq!(&response.file, expected, "{parameter}");
+    }
+    assert!(!emit::Options::default().file_per_package);
+}
+
+#[test]
+fn invalid_file_per_package_returns_error_without_files() {
+    let mut request = request();
+    for value in ["", "no", "0", "TRUE"] {
+        request.parameter = Some(format!("packaging=false,file_per_package={value}"));
+        let response = invoke_plugin(&request);
+        assert!(
+            response
+                .error
+                .unwrap()
+                .contains("file_per_package must be true or false")
+        );
+        assert!(response.file.is_empty());
+    }
+}
+
+#[test]
+fn packaged_unnamed_package_uses_buffa_stem_and_root_import() {
+    let mut request = request();
+    request.file_to_generate = vec!["second.proto".into()];
+    request.proto_file[1].package = None;
+    request.parameter = Some("file_per_package=true".into());
+    let response = invoke_plugin(&request);
+    assert!(response.error.is_none(), "{:?}", response.error);
+    let names: Vec<_> = response
+        .file
+        .iter()
+        .map(|f| f.name.as_deref().unwrap())
+        .collect();
+    assert_eq!(names, ["__buffa.rs", "__buffa.mod.rs", "mod.rs"]);
+    let root = response.file[2].content.as_deref().unwrap();
+    assert!(root.contains("use crate::proto::*;"));
+    assert!(root.contains("include!(\"__buffa.mod.rs\");"));
 }

--- a/crates/protovalidate-buffa-conformance/build.rs
+++ b/crates/protovalidate-buffa-conformance/build.rs
@@ -281,6 +281,14 @@ fn write_module_tree_fixtures(
                 ..Default::default()
             },
         ),
+        (
+            "grouped",
+            protoc_gen_protovalidate_buffa::emit::Options {
+                proto_module: "crate::grouped::proto".to_string(),
+                file_per_package: true,
+                ..Default::default()
+            },
+        ),
     ] {
         let destination = fixture_dir.join(directory);
         std::fs::create_dir_all(&destination).expect("create module-tree fixture directory");
@@ -303,6 +311,7 @@ fn write_module_tree_fixtures(
     let messages = path_literal(messages_dir.join("mod.rs"));
     let default = path_literal(fixture_dir.join("default/mod.rs"));
     let custom = path_literal(fixture_dir.join("custom/mod.rs"));
+    let grouped = path_literal(fixture_dir.join("grouped/mod.rs"));
     let mounts = quote::quote! {
         #[path = #messages]
         mod proto;
@@ -314,6 +323,12 @@ fn write_module_tree_fixtures(
         mod default_validators;
         #[path = #custom]
         mod custom_validators;
+        mod grouped {
+            #[path = #messages]
+            pub(crate) mod proto;
+            #[path = #grouped]
+            mod validators;
+        }
     };
     std::fs::write(out_dir.join("module_tree_mounts.rs"), mounts.to_string())
         .expect("write module-tree root mounts");

--- a/crates/protovalidate-buffa-conformance/build.rs
+++ b/crates/protovalidate-buffa-conformance/build.rs
@@ -215,6 +215,7 @@ fn write_field_name_fixtures(
             .expect("scan field-name fixtures");
         let options = protoc_gen_protovalidate_buffa::emit::Options {
             proto_module: format!("crate::{mode}::proto"),
+            ..Default::default()
         };
         let validators = directory.join("validators");
         std::fs::create_dir_all(&validators).expect("create naming validators directory");
@@ -277,6 +278,7 @@ fn write_module_tree_fixtures(
             "custom",
             protoc_gen_protovalidate_buffa::emit::Options {
                 proto_module: "crate::custom::messages".to_string(),
+                ..Default::default()
             },
         ),
     ] {

--- a/crates/protovalidate-buffa-conformance/tests/emit_module_tree.rs
+++ b/crates/protovalidate-buffa-conformance/tests/emit_module_tree.rs
@@ -62,3 +62,5 @@ module_tree_tests!(default_runtime, crate::proto, runtime);
 module_tree_tests!(default_desktop, crate::proto, desktop);
 module_tree_tests!(custom_runtime, crate::custom::messages, runtime);
 module_tree_tests!(custom_desktop, crate::custom::messages, desktop);
+module_tree_tests!(grouped_runtime, crate::grouped::proto, runtime);
+module_tree_tests!(grouped_desktop, crate::grouped::proto, desktop);

--- a/examples/packaging/Cargo.toml
+++ b/examples/packaging/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "protovalidate-buffa-packaging-examples"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Runnable examples of validators mounted beside Buffa message types."
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
+
+[dependencies]
+buffa = "0.9.1"
+protovalidate-buffa = { path = "../../crates/protovalidate-buffa", version = "0.7.2", default-features = false }
+
+[build-dependencies]
+anyhow = "1"
+buffa = "0.9.1"
+buffa-codegen = "0.9.1"
+protoc-gen-protovalidate-buffa = { path = "../../crates/protoc-gen-protovalidate-buffa", version = "0.9.1" }
+
+[lints]
+workspace = true

--- a/examples/packaging/README.md
+++ b/examples/packaging/README.md
@@ -1,9 +1,12 @@
 # Packaging examples
 
-Both examples generate Buffa types with `file_per_package=true` and validators
-with `packaging=false` into the same directory. Handwritten Rust modules include
-the types and validators together. The build script uses the workspace's plugin
-library, so you can try a checkout without installing a plugin binary.
+Both examples generate Buffa types and validators into the same directory.
+Handwritten Rust modules include the types and validators together. The
+validator plugin's `packaging` and `file_per_package` flags are independent:
+the first example disables packaging with per-source output, and the second
+also enables per-package output. Buffa uses `file_per_package=true` in both.
+The build script uses the workspace's plugin library, so you can try a checkout
+without installing a plugin binary.
 
 You need Rust and `protoc` on `PATH`, or set `PROTOC` to its executable. From
 the repository root:
@@ -14,26 +17,28 @@ cargo run -p protovalidate-buffa-packaging-examples --bin same_module
 cargo run -p protovalidate-buffa-packaging-examples --bin split_package
 ```
 
-## One package in one module
+## Per-source validators in one module
 
 [`same_module.rs`](src/bin/same_module.rs) mounts the types and validators for
 [`user.proto`](proto/user.proto) inside `mod users`. It accepts a valid email
 and rejects an invalid one, using both `User` and `UserView`.
+It sets `packaging=false` and leaves `file_per_package=false` at its default.
 
 ```rust
 mod users {
     include!(concat!(env!("OUT_DIR"), "/example.users.v1.rs"));
-    include!(concat!(env!("OUT_DIR"), "/example.users.v1.validate.rs"));
+    include!(concat!(env!("OUT_DIR"), "/user.validate.rs"));
 }
 ```
 
 This package has no cross-package references, so the module can use any name.
 
-## A package split across files
+## Per-package validators across source files
 
 [`split_package.rs`](src/bin/split_package.rs) mounts `example.orders.v1`,
 which contains [`Order`](proto/order.proto) and [`LineItem`](proto/line_item.proto)
-in separate source files. A single `example.orders.v1.validate.rs` contains both
+in separate source files. It sets `packaging=false,file_per_package=true`.
+A single `example.orders.v1.validate.rs` contains both
 validators. Adding another message file to that package needs no new include.
 
 `LineItem` references [`Currency`](proto/shared/currency.proto) from

--- a/examples/packaging/README.md
+++ b/examples/packaging/README.md
@@ -1,0 +1,68 @@
+# Packaging examples
+
+Both examples generate Buffa types with `file_per_package=true` and validators
+with `packaging=false` into the same directory. Handwritten Rust modules include
+the types and validators together. The build script uses the workspace's plugin
+library, so you can try a checkout without installing a plugin binary.
+
+You need Rust and `protoc` on `PATH`, or set `PROTOC` to its executable. From
+the repository root:
+
+```sh
+mise install rust protoc
+cargo run -p protovalidate-buffa-packaging-examples --bin same_module
+cargo run -p protovalidate-buffa-packaging-examples --bin split_package
+```
+
+## One package in one module
+
+[`same_module.rs`](src/bin/same_module.rs) mounts the types and validators for
+[`user.proto`](proto/user.proto) inside `mod users`. It accepts a valid email
+and rejects an invalid one, using both `User` and `UserView`.
+
+```rust
+mod users {
+    include!(concat!(env!("OUT_DIR"), "/example.users.v1.rs"));
+    include!(concat!(env!("OUT_DIR"), "/example.users.v1.validate.rs"));
+}
+```
+
+This package has no cross-package references, so the module can use any name.
+
+## A package split across files
+
+[`split_package.rs`](src/bin/split_package.rs) mounts `example.orders.v1`,
+which contains [`Order`](proto/order.proto) and [`LineItem`](proto/line_item.proto)
+in separate source files. A single `example.orders.v1.validate.rs` contains both
+validators. Adding another message file to that package needs no new include.
+
+`LineItem` references [`Currency`](proto/shared/currency.proto) from
+`example.money.v1`. The handwritten modules preserve the package hierarchy so
+Buffa's relative paths resolve. It also imports `crate::example` in the orders
+module so validators can resolve the enum's `example::money::v1::Currency` path.
+The currency
+package has no messages and needs no validator file. Source directories do
+not mirror package names in these schemas.
+
+The program checks valid orders, invalid quantities, unknown enum values, and
+empty orders. It validates owned messages and views and checks the violation
+paths for nested line items.
+
+## Generation and tests
+
+[`build.rs`](build.rs) compiles the schemas once and passes the resulting
+descriptors to both generators. It uses the repository's existing
+`buf/validate/validate.proto`; no schema downloads are needed. Cargo writes
+the generated files under `OUT_DIR`.
+
+To use the same layout with `buf generate`, configure the plugin pair as shown
+in the [root README](../../README.md#include-validators-beside-message-types).
+Keep `strategy: all` so each package's source files reach the plugin in one
+request. `proto_module` has no effect when packaging is disabled.
+
+CI runs both examples' behavior tests through `cargo test --workspace
+--all-targets`. To run just these tests:
+
+```sh
+cargo test -p protovalidate-buffa-packaging-examples
+```

--- a/examples/packaging/build.rs
+++ b/examples/packaging/build.rs
@@ -34,7 +34,7 @@ fn main() -> anyhow::Result<()> {
         "protoc failed to compile the example schemas"
     );
     let fds = FileDescriptorSet::decode_from_slice(&fs::read(descriptors)?)?;
-    let request = CodeGeneratorRequest {
+    let mut request = CodeGeneratorRequest {
         file_to_generate: sources.into_iter().map(str::to_string).collect(),
         proto_file: fds.file,
         ..Default::default()
@@ -47,15 +47,30 @@ fn main() -> anyhow::Result<()> {
     for file in buffa_codegen::generate(&request.proto_file, &request.file_to_generate, &config)? {
         fs::write(out.join(&file.name), file.content)?;
     }
-    let options = emit::Options {
-        packaging: false,
-        ..Default::default()
-    };
-    for file in emit::render_with_options(&scan::gather(&request)?, &options)? {
-        fs::write(
-            out.join(file.name.as_deref().expect("generated filename")),
-            file.content.as_deref().expect("generated content"),
-        )?;
+    for (sources, options) in [
+        (
+            &["user.proto"][..],
+            emit::Options {
+                packaging: false,
+                ..Default::default()
+            },
+        ),
+        (
+            &["order.proto", "line_item.proto", "shared/currency.proto"][..],
+            emit::Options {
+                packaging: false,
+                file_per_package: true,
+                ..Default::default()
+            },
+        ),
+    ] {
+        request.file_to_generate = sources.iter().map(|s| (*s).to_string()).collect();
+        for file in emit::render_with_options(&scan::gather(&request)?, &options)? {
+            fs::write(
+                out.join(file.name.as_deref().expect("generated filename")),
+                file.content.as_deref().expect("generated content"),
+            )?;
+        }
     }
     Ok(())
 }

--- a/examples/packaging/build.rs
+++ b/examples/packaging/build.rs
@@ -1,0 +1,61 @@
+//! Generate both examples from the same descriptors for Buffa and validation.
+
+use std::{env, fs, path::PathBuf, process::Command};
+
+use buffa::Message as _;
+use buffa_codegen::{
+    CodeGenConfig,
+    generated::{compiler::CodeGeneratorRequest, descriptor::FileDescriptorSet},
+};
+use protoc_gen_protovalidate_buffa::{emit, scan};
+
+fn main() -> anyhow::Result<()> {
+    let out = PathBuf::from(env::var("OUT_DIR")?);
+    let schemas = "../../crates/protovalidate-buffa-protos/proto";
+    println!("cargo:rerun-if-changed=proto");
+    println!("cargo:rerun-if-changed={schemas}");
+    println!("cargo:rerun-if-env-changed=PROTOC");
+    let sources = [
+        "user.proto",
+        "order.proto",
+        "line_item.proto",
+        "shared/currency.proto",
+    ];
+    let descriptors = out.join("examples.binpb");
+    let status = Command::new(env::var_os("PROTOC").unwrap_or_else(|| "protoc".into()))
+        .arg("-Iproto")
+        .arg(format!("-I{schemas}"))
+        .arg("--include_imports")
+        .arg(format!("--descriptor_set_out={}", descriptors.display()))
+        .args(sources)
+        .status()?;
+    anyhow::ensure!(
+        status.success(),
+        "protoc failed to compile the example schemas"
+    );
+    let fds = FileDescriptorSet::decode_from_slice(&fs::read(descriptors)?)?;
+    let request = CodeGeneratorRequest {
+        file_to_generate: sources.into_iter().map(str::to_string).collect(),
+        proto_file: fds.file,
+        ..Default::default()
+    };
+
+    let mut config = CodeGenConfig::default();
+    config.file_per_package = true;
+    // Both plugins write to one directory. The handwritten Rust modules below
+    // include only each package's types and validators.
+    for file in buffa_codegen::generate(&request.proto_file, &request.file_to_generate, &config)? {
+        fs::write(out.join(&file.name), file.content)?;
+    }
+    let options = emit::Options {
+        packaging: false,
+        ..Default::default()
+    };
+    for file in emit::render_with_options(&scan::gather(&request)?, &options)? {
+        fs::write(
+            out.join(file.name.as_deref().expect("generated filename")),
+            file.content.as_deref().expect("generated content"),
+        )?;
+    }
+    Ok(())
+}

--- a/examples/packaging/proto/line_item.proto
+++ b/examples/packaging/proto/line_item.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package example.orders.v1;
+
+import "buf/validate/validate.proto";
+import "shared/currency.proto";
+
+message LineItem {
+  int32 quantity = 1 [(buf.validate.field).int32.gt = 0];
+  example.money.v1.Currency currency = 2 [(buf.validate.field).enum.defined_only = true];
+}

--- a/examples/packaging/proto/order.proto
+++ b/examples/packaging/proto/order.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package example.orders.v1;
+
+import "buf/validate/validate.proto";
+import "line_item.proto";
+
+message Order {
+  repeated LineItem items = 1 [(buf.validate.field).repeated.min_items = 1];
+}

--- a/examples/packaging/proto/shared/currency.proto
+++ b/examples/packaging/proto/shared/currency.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package example.money.v1;
+
+enum Currency {
+  CURRENCY_UNSPECIFIED = 0;
+  CURRENCY_USD = 1;
+  CURRENCY_EUR = 2;
+}

--- a/examples/packaging/proto/user.proto
+++ b/examples/packaging/proto/user.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package example.users.v1;
+
+import "buf/validate/validate.proto";
+
+message User {
+  string email = 1 [(buf.validate.field).string.email = true];
+}

--- a/examples/packaging/src/bin/same_module.rs
+++ b/examples/packaging/src/bin/same_module.rs
@@ -1,0 +1,48 @@
+//! Include a package's types and validators in one handwritten module.
+//!
+//! Run: `cargo run -p protovalidate-buffa-packaging-examples --bin same_module`
+#![warn(rust_2018_idioms)]
+
+use buffa::{Message as _, MessageView as _};
+use protovalidate_buffa::Validate as _;
+
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    unused_imports,
+    reason = "Buffa and validator generated code"
+)]
+mod users {
+    include!(concat!(env!("OUT_DIR"), "/example.users.v1.rs"));
+    include!(concat!(env!("OUT_DIR"), "/example.users.v1.validate.rs"));
+}
+
+fn main() {
+    validate_users();
+    println!(
+        "same_module: valid email accepted; invalid email rejected for owned messages and views"
+    );
+}
+
+fn validate_users() {
+    for (email, valid) in [("ada@example.com", true), ("invalid", false)] {
+        let user = users::User {
+            email: email.into(),
+            ..Default::default()
+        };
+        let bytes = user.encode_to_vec();
+        let view = users::__buffa::view::UserView::decode_view(&bytes).expect("decode user view");
+        assert_eq!(user.validate().is_ok(), valid);
+        assert_eq!(view.validate().is_ok(), valid);
+        if !valid {
+            let error = user.validate().unwrap_err();
+            assert_eq!(error.violations[0].rule_id, "string.email");
+        }
+    }
+}
+
+#[test]
+fn same_module_validates_owned_and_borrowed_users() {
+    validate_users();
+}

--- a/examples/packaging/src/bin/same_module.rs
+++ b/examples/packaging/src/bin/same_module.rs
@@ -15,7 +15,7 @@ use protovalidate_buffa::Validate as _;
 )]
 mod users {
     include!(concat!(env!("OUT_DIR"), "/example.users.v1.rs"));
-    include!(concat!(env!("OUT_DIR"), "/example.users.v1.validate.rs"));
+    include!(concat!(env!("OUT_DIR"), "/user.validate.rs"));
 }
 
 fn main() {

--- a/examples/packaging/src/bin/split_package.rs
+++ b/examples/packaging/src/bin/split_package.rs
@@ -1,0 +1,82 @@
+//! Two source files share one validator include; a sibling package supplies an enum.
+//!
+//! Run: `cargo run -p protovalidate-buffa-packaging-examples --bin split_package`
+#![warn(rust_2018_idioms)]
+
+use buffa::{Message as _, MessageView as _};
+use protovalidate_buffa::Validate as _;
+
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    elided_lifetimes_in_paths,
+    unused_imports,
+    reason = "Buffa and validator generated code"
+)]
+mod example {
+    pub mod money {
+        pub mod v1 {
+            // This package has only an enum, so it needs no validator file.
+            include!(concat!(env!("OUT_DIR"), "/example.money.v1.rs"));
+        }
+    }
+    pub mod orders {
+        pub mod v1 {
+            // Enum validation uses protobuf paths beginning at `example`.
+            use crate::example;
+
+            include!(concat!(env!("OUT_DIR"), "/example.orders.v1.rs"));
+            include!(concat!(env!("OUT_DIR"), "/example.orders.v1.validate.rs"));
+        }
+    }
+}
+
+fn main() {
+    validate_orders();
+    println!(
+        "split_package: orders, line items, and cross-package currency enums validated for owned messages and views"
+    );
+}
+
+fn validate_orders() {
+    use example::orders::v1::{__buffa::view::OrderView, LineItem, Order};
+
+    for (quantity, currency, expected_rule) in [
+        (2, 1, None),
+        (0, 1, Some("int32.gt")),
+        (2, 99, Some("enum.defined_only")),
+    ] {
+        let order = Order {
+            items: vec![LineItem {
+                quantity,
+                currency: buffa::EnumValue::from(currency),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let bytes = order.encode_to_vec();
+        let view = OrderView::decode_view(&bytes).expect("decode order view");
+        for result in [order.validate(), view.validate()] {
+            if let Some(rule) = expected_rule {
+                let error = result.expect_err("invalid line item must fail");
+                assert_eq!(error.violations[0].rule_id, rule);
+                assert_eq!(
+                    error.violations[0].field.elements[0].field_name.as_deref(),
+                    Some("items")
+                );
+            } else {
+                result.expect("valid order");
+            }
+        }
+    }
+    assert_eq!(
+        Order::default().validate().unwrap_err().violations[0].rule_id,
+        "repeated.min_items"
+    );
+}
+
+#[test]
+fn split_package_validates_nested_messages_and_cross_package_enums() {
+    validate_orders();
+}


### PR DESCRIPTION
Add two independent generator options so validators can share an output directory and Rust module with the Buffa types they validate:

- `packaging=false` omits `mod.rs` and `<package>.mod.rs` and adds `.validate` to validator filenames. It ignores `proto_module` and keeps per-source output unless grouping is enabled.
- `file_per_package=true` groups validators by declared protobuf package, independently of packaging. Both flags together emit one `<package>.validate.rs` per package.

Defaults preserve the existing output. Both flags accept bare, true, and false forms; invalid values return a plugin error without output files. Package grouping handles multiple source files, source directories that differ from package names, and the unnamed package using Buffa's filename convention.

Add two runnable examples under `examples/packaging`: `same_module` uses per-source validators, and `split_package` uses per-package validators with a cross-package currency enum. Both exercise owned messages and borrowed views. Integration tests cover all four flag combinations and compile package grouping with the generated module tree as well.

**Library compatibility:** `emit::Options` gains `packaging` and `file_per_package` fields. Callers constructing struct literals must set both or add `..Default::default()`. This warrants a minor bump to 0.10.0 for the pre-1.0 generator; default CLI output remains byte-for-byte identical to 0.9.1.

Validation:
- `cargo test --locked --workspace --all-features --all-targets`: 257 passed, including all four option combinations and generated-code integration tests
- `cargo build --locked --workspace`
- `cargo test --locked -p protoc-gen-protovalidate-buffa --doc`: 2 passed
- `hk check --all --slow`: passed, including Clippy, formatting, and dependency audit
- Both example binaries ran successfully; upstream conformance: 2,872 passed, 0 failed or skipped
- `cargo package --list --locked --workspace`
- Direct protoc smoke tests preserved a handwritten `mod.rs` in both per-source and per-package modes
- Default output compared byte-for-byte with the released 0.9.1 binary

Implements https://github.com/mathematic-inc/protovalidate-buffa/discussions/58 with independent controls for packaging and grouping. Thanks to @iamralch for the proposal and explanation of the shared-module workflow.
